### PR TITLE
[codex] Document skill requirements and harden MCP planning

### DIFF
--- a/.claude/commands/splunk-connect-for-otlp-setup.md
+++ b/.claude/commands/splunk-connect-for-otlp-setup.md
@@ -1,0 +1,3 @@
+Install, configure, validate, diagnose, and repair Splunk Connect for OTLP, including OTLP sender handoffs and HEC-token guardrails.
+
+Read and follow the instructions in skills/splunk-connect-for-otlp-setup/SKILL.md to help the user. If more detail is needed, also read skills/splunk-connect-for-otlp-setup/reference.md.

--- a/.cursor/skills/splunk-connect-for-otlp-setup
+++ b/.cursor/skills/splunk-connect-for-otlp-setup
@@ -1,0 +1,1 @@
+../../skills/splunk-connect-for-otlp-setup

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ The user can also invoke skills directly as slash commands (e.g. `/cisco-catalys
 | `splunk-agent-management-setup` | Splunk Agent Management | Render, apply, and validate server classes, deployment apps, and deployment client assets |
 | `splunk-workload-management-setup` | Splunk Workload Management | Render and validate workload pools, workload rules, admission-rule guardrails, and Linux workload prerequisites |
 | `splunk-hec-service-setup` | Splunk HTTP Event Collector | Prepare reusable HEC token configuration, allowed indexes, Enterprise inputs.conf assets, and Splunk Cloud ACS payloads |
+| `splunk-connect-for-otlp-setup` | `splunk-connect-for-otlp` | Install, configure, validate, diagnose, and repair Splunk Connect for OTLP app `8704`; render OTLP sender configs and HEC-token handoffs without exposing token values |
 | `splunk-federated-search-setup` | Splunk Federated Search | Render and validate self-managed Splunk-to-Splunk standard or transparent providers, standard-mode federated indexes, and SHC replication assets |
 | `splunk-index-lifecycle-smartstore-setup` | Splunk Index Lifecycle / SmartStore | Render and validate SmartStore `indexes.conf`, `server.conf`, and `limits.conf` assets for indexers or cluster managers |
 | `splunk-monitoring-console-setup` | Splunk Monitoring Console | Render and validate self-managed distributed or standalone Monitoring Console assets, including auto-config, peer/group review, forwarder monitoring, and platform alerts |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ The user can also invoke skills directly as slash commands (e.g. `/cisco-catalys
 | `splunk-agent-management-setup` | Splunk Agent Management | Render, apply, and validate server classes, deployment apps, and deployment client assets |
 | `splunk-workload-management-setup` | Splunk Workload Management | Render and validate workload pools, workload rules, admission-rule guardrails, and Linux workload prerequisites |
 | `splunk-hec-service-setup` | Splunk HTTP Event Collector | Prepare reusable HEC token configuration, allowed indexes, Enterprise inputs.conf assets, and Splunk Cloud ACS payloads |
+| `splunk-connect-for-otlp-setup` | `splunk-connect-for-otlp` | Install, configure, validate, diagnose, and repair Splunk Connect for OTLP app `8704`; render OTLP sender configs and HEC-token handoffs without exposing token values |
 | `splunk-federated-search-setup` | Splunk Federated Search | Render and validate self-managed Splunk-to-Splunk standard or transparent providers, standard-mode federated indexes, and SHC replication assets |
 | `splunk-index-lifecycle-smartstore-setup` | Splunk Index Lifecycle / SmartStore | Render and validate SmartStore `indexes.conf`, `server.conf`, and `limits.conf` assets for indexers or cluster managers |
 | `splunk-monitoring-console-setup` | Splunk Monitoring Console | Render and validate self-managed distributed or standalone Monitoring Console assets, including auto-config, peer/group review, forwarder monitoring, and platform alerts |

--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ planning, rendering, installing, configuring, validating, and handing off Splunk
 Platform, Splunk Cloud, Splunk Observability Cloud, Cisco, and adjacent
 operational integrations.
 
-The catalog covers Cisco product onboarding, Splunk apps and TAs, Enterprise Security 
-and the broader Splunk security portfolio, ITSI, SOAR, On-Call, Observability Cloud 
-integrations, dashboards, detectors, OpenTelemetry collectors, Kubernetes APM
-auto-instrumentation, Browser RUM and Session Replay, AWS and ThousandEyes
-integrations, HEC, ACS allowlists, PKI, SmartStore, federated search, workload
-management, Monitoring Console, license management, indexer clusters, Edge
-Processor, Stream, SC4S, SC4SNMP, Universal Forwarders, Linux Splunk Enterprise
-hosts, self-managed Kubernetes runtimes, and external-collector topologies.
+The catalog covers Cisco product onboarding, Splunk apps and TAs, Enterprise
+Security and the broader Splunk security portfolio, ITSI, SOAR, On-Call,
+Observability Cloud integrations, AI Agent Monitoring, Database Monitoring,
+dashboards, detectors, OpenTelemetry collectors, Kubernetes APM
+auto-instrumentation, Browser RUM and Session Replay, AWS, ThousandEyes, and
+OTLP integrations, HEC, ACS allowlists, PKI, SmartStore, federated search,
+workload management, Monitoring Console, license management, indexer clusters,
+Edge Processor, Stream, Splunk Connect for OTLP, SC4S, SC4SNMP, Universal
+Forwarders, Linux Splunk Enterprise hosts, self-managed Kubernetes runtimes, and
+external-collector topologies.
 Most workflows are render-first and validation-heavy, with explicit apply
 phases and secret-file guardrails for production changes.
 
@@ -63,10 +65,28 @@ Common starting points:
   `skills/splunk-security-portfolio-setup/`; it routes Enterprise Security,
   SOAR, Security Essentials, UBA, Attack Analyzer, ARI, and related offerings
   to the supported setup, install-only, or handoff path.
+- If you need a broad Splunk Cloud or Enterprise administration health review,
+  start with `skills/splunk-admin-doctor/`; it diagnoses admin-domain coverage
+  and renders doctor reports, fix plans, and safe handoffs.
+- If you need Splunk Cloud Data Manager onboarding for AWS, Azure, GCP, or
+  CrowdStrike, start with `skills/splunk-cloud-data-manager-setup/`. It works
+  from Data Manager-generated artifacts and keeps private Data Manager APIs out
+  of scope.
 - If you need Splunk Observability Cloud OTel collection on Kubernetes or a
   Linux host, start with `skills/splunk-observability-otel-collector-setup/`.
   The workflow renders Helm and Linux installer assets first, then applies only
   when requested.
+- If you need OTLP senders to land in Splunk Platform through the Splunk Connect
+  for OTLP modular input, start with
+  `skills/splunk-connect-for-otlp-setup/`; use `skills/splunk-hec-service-setup/`
+  for the HEC token prerequisite.
+- If you need Splunk Observability Cloud Database Monitoring for PostgreSQL,
+  Microsoft SQL Server, or Oracle Database, start with
+  `skills/splunk-observability-database-monitoring-setup/`.
+- If you need Splunk AI Agent Monitoring or AI Infrastructure Monitoring, start
+  with `skills/splunk-observability-ai-agent-monitoring-setup/`.
+- If you need AWS metrics and CloudWatch integration assets for Splunk
+  Observability Cloud, start with `skills/splunk-observability-aws-integration/`.
 - If you need to pair the Splunk Platform with Splunk Observability Cloud
   (Unified Identity, the Discover Splunk Observability Cloud app, Log Observer
   Connect, Related Content, the Splunk Infrastructure Monitoring Add-on), start
@@ -166,8 +186,9 @@ At a high level, the repo gives you seven layers of automation:
    or install them from local `.tgz` or `.spl` files. In Splunk Cloud, installs
    are executed through ACS instead of direct `/services/apps/local` calls.
 4. **App-specific setup**: create indexes, configure accounts, enable inputs,
-   update macros, and apply dashboard settings. In Splunk Cloud, index creation
-   uses ACS and the app-specific REST configuration uses the search tier.
+   update macros, configure modular inputs, and apply dashboard settings. In
+   Splunk Cloud, index creation uses ACS and the app-specific REST configuration
+   uses the search tier.
 5. **Platform administration workflows**: render and optionally apply
    self-managed Splunk Enterprise service configuration for Agent Management,
    Workload Management, Federated Search, SmartStore/index lifecycle, Monitoring
@@ -180,15 +201,15 @@ At a high level, the repo gives you seven layers of automation:
    the ACS allowlist workflow manages Cloud control-plane allowlists.
 6. **External collectors and observability**: render and optionally apply
    customer-managed SC4S, SC4SNMP, Splunk Edge Processor, and Splunk OTel
-   Collector runtimes that send data to Splunk Cloud, Splunk Enterprise HEC, or
-   Splunk Observability Cloud; wire the Splunk Platform to Splunk Observability
-   Cloud (Unified Identity, Discover Splunk Observability Cloud app, Log
-   Observer Connect, Splunk Infrastructure Monitoring Add-on); overlay
-   zero-code Kubernetes application auto-instrumentation and Browser RUM +
-   Session Replay injection; wire Cisco Nexus, Intersight, Isovalent, NVIDIA
-   GPU, Cisco AI Pod, and ThousandEyes sources into Splunk Observability
-   Cloud; and build reviewed Observability dashboard, detector, alert routing,
-   and Splunk On-Call artifacts.
+   Collector runtimes; configure Splunk Connect for OTLP listener placement and
+   sender handoffs; wire the Splunk Platform to Splunk Observability Cloud
+   (Unified Identity, Discover Splunk Observability Cloud app, Log Observer
+   Connect, Splunk Infrastructure Monitoring Add-on); overlay zero-code
+   Kubernetes application auto-instrumentation, Browser RUM + Session Replay
+   injection, Database Monitoring, and AI Agent Monitoring; wire AWS, Cisco
+   Nexus, Intersight, Isovalent, NVIDIA GPU, Cisco AI Pod, and ThousandEyes
+   sources into Splunk Observability Cloud; and build reviewed Observability
+   dashboard, detector, alert routing, and Splunk On-Call artifacts.
 7. **Validation**: confirm the app is installed, the expected objects exist, and
    Splunk is actually receiving data.
 
@@ -836,53 +857,9 @@ splunk-cisco-skills/
 │   │       ├── generate_skill_ux_catalog.py  # refresh SKILL_UX_CATALOG.md
 │   │       ├── smoke_sc4x_live.sh            # SC4S/SC4SNMP live smoke test
 │   │       └── test_splunkbase_connection.sh # Splunkbase credential check
-│   ├── splunk-app-install/
-│   ├── splunk-ai-assistant-setup/
-│   ├── splunk-agent-management-setup/
-│   ├── splunk-universal-forwarder-setup/
-│   ├── splunk-workload-management-setup/
-│   ├── splunk-hec-service-setup/
-│   ├── splunk-federated-search-setup/
-│   ├── splunk-index-lifecycle-smartstore-setup/
-│   ├── splunk-monitoring-console-setup/
-│   ├── splunk-enterprise-host-setup/
-│   ├── splunk-enterprise-kubernetes-setup/
-│   ├── splunk-enterprise-security-install/
-│   ├── splunk-enterprise-security-config/
-│   ├── splunk-security-portfolio-setup/
-│   ├── splunk-security-essentials-setup/
-│   ├── splunk-asset-risk-intelligence-setup/
-│   ├── splunk-attack-analyzer-setup/
-│   ├── splunk-uba-setup/
-│   ├── splunk-soar-setup/
-│   ├── splunk-observability-otel-collector-setup/
-│   ├── splunk-observability-k8s-auto-instrumentation-setup/
-│   ├── splunk-observability-k8s-frontend-rum-setup/
-│   ├── splunk-observability-cloud-integration-setup/
-│   ├── splunk-observability-thousandeyes-integration/
-│   ├── splunk-observability-isovalent-integration/
-│   ├── splunk-observability-cisco-nexus-integration/
-│   ├── splunk-observability-cisco-intersight-integration/
-│   ├── splunk-observability-nvidia-gpu-integration/
-│   ├── splunk-observability-cisco-ai-pod-integration/
-│   ├── splunk-observability-dashboard-builder/
-│   ├── splunk-observability-native-ops/
-│   ├── splunk-oncall-setup/
-│   ├── splunk-connect-for-syslog-setup/
-│   ├── splunk-connect-for-snmp-setup/
-│   ├── splunk-license-manager-setup/
-│   ├── splunk-indexer-cluster-setup/
-│   ├── splunk-edge-processor-setup/
-│   ├── splunk-cloud-acs-allowlist-setup/
-│   ├── splunk-enterprise-public-exposure-hardening/
-│   ├── splunk-platform-pki-setup/
-│   ├── splunk-itsi-config/
-│   ├── splunk-itsi-setup/
-│   ├── splunk-mcp-server-setup/
-│   ├── splunk-stream-setup/
 │   ├── cisco-appdynamics-setup/
-│   ├── cisco-catalyst-ta-setup/
 │   ├── cisco-catalyst-enhanced-netflow-setup/
+│   ├── cisco-catalyst-ta-setup/
 │   ├── cisco-dc-networking-setup/
 │   ├── cisco-enterprise-networking-setup/
 │   ├── cisco-intersight-setup/
@@ -891,10 +868,64 @@ splunk-cisco-skills/
 │   ├── cisco-product-setup/
 │   ├── cisco-scan-setup/
 │   ├── cisco-secure-access-setup/
+│   ├── cisco-secure-email-web-gateway-setup/
 │   ├── cisco-security-cloud-setup/
 │   ├── cisco-spaces-setup/
+│   ├── cisco-talos-intelligence-setup/
 │   ├── cisco-thousandeyes-mcp-setup/
-│   └── cisco-thousandeyes-setup/
+│   ├── cisco-thousandeyes-setup/
+│   ├── cisco-ucs-ta-setup/
+│   ├── cisco-webex-setup/
+│   ├── splunk-admin-doctor/
+│   ├── splunk-agent-management-setup/
+│   ├── splunk-ai-assistant-setup/
+│   ├── splunk-app-install/
+│   ├── splunk-asset-risk-intelligence-setup/
+│   ├── splunk-attack-analyzer-setup/
+│   ├── splunk-cloud-acs-allowlist-setup/
+│   ├── splunk-cloud-data-manager-setup/
+│   ├── splunk-connect-for-otlp-setup/
+│   ├── splunk-connect-for-snmp-setup/
+│   ├── splunk-connect-for-syslog-setup/
+│   ├── splunk-edge-processor-setup/
+│   ├── splunk-enterprise-host-setup/
+│   ├── splunk-enterprise-kubernetes-setup/
+│   ├── splunk-enterprise-public-exposure-hardening/
+│   ├── splunk-enterprise-security-config/
+│   ├── splunk-enterprise-security-install/
+│   ├── splunk-federated-search-setup/
+│   ├── splunk-hec-service-setup/
+│   ├── splunk-index-lifecycle-smartstore-setup/
+│   ├── splunk-indexer-cluster-setup/
+│   ├── splunk-itsi-config/
+│   ├── splunk-itsi-setup/
+│   ├── splunk-license-manager-setup/
+│   ├── splunk-mcp-server-setup/
+│   ├── splunk-monitoring-console-setup/
+│   ├── splunk-observability-ai-agent-monitoring-setup/
+│   ├── splunk-observability-aws-integration/
+│   ├── splunk-observability-cisco-ai-pod-integration/
+│   ├── splunk-observability-cisco-intersight-integration/
+│   ├── splunk-observability-cisco-nexus-integration/
+│   ├── splunk-observability-cloud-integration-setup/
+│   ├── splunk-observability-dashboard-builder/
+│   ├── splunk-observability-database-monitoring-setup/
+│   ├── splunk-observability-isovalent-integration/
+│   ├── splunk-observability-k8s-auto-instrumentation-setup/
+│   ├── splunk-observability-k8s-frontend-rum-setup/
+│   ├── splunk-observability-native-ops/
+│   ├── splunk-observability-nvidia-gpu-integration/
+│   ├── splunk-observability-otel-collector-setup/
+│   ├── splunk-observability-thousandeyes-integration/
+│   ├── splunk-oncall-setup/
+│   ├── splunk-platform-pki-setup/
+│   ├── splunk-security-essentials-setup/
+│   ├── splunk-security-portfolio-setup/
+│   ├── splunk-soar-setup/
+│   ├── splunk-stream-setup/
+│   ├── splunk-uba-setup/
+│   ├── splunk-universal-forwarder-setup/
+│   └── splunk-workload-management-setup/
 ├── tests/                       # bats and Python test suites
 └── rules/
     └── credential-handling.mdc
@@ -981,6 +1012,11 @@ Minimum expected environment:
   workflows
 - a `splunk.com` account for Splunkbase downloads when installing public apps
 
+For the per-skill software and live-access matrix, see
+[`SKILL_REQUIREMENTS.md`](SKILL_REQUIREMENTS.md). It calls out workflow-specific
+tools such as `kubectl`, `helm`, `yq`, `node`, `mcp-remote`, Docker/Podman,
+Terraform, cloud CLIs, and `splunk-rum` only where those skills need them.
+
 For Splunk Cloud workflows, you should also install the ACS CLI:
 
 ```bash
@@ -1003,9 +1039,11 @@ that will run the generated assets.
 
 ## Current Scope
 
-This repo focuses on vendor TAs/apps that can be configured through REST and
-shell automation on **self-managed Splunk Enterprise** and on **Splunk Cloud
-search tiers with ACS plus allowlisted REST API access**.
+This repo focuses on vendor TAs/apps, Splunk administration workflows, and
+customer-managed collection or integration runtimes that can be configured
+through REST, shell automation, rendered assets, or explicit handoffs on
+**self-managed Splunk Enterprise** and on **Splunk Cloud search tiers with ACS
+plus allowlisted REST API access**.
 
 The platform administration skills deliberately separate self-managed
 Enterprise file-render workflows from Splunk Cloud managed features:
@@ -1024,6 +1062,13 @@ self-managed Enterprise control planes; Splunk Cloud licensing and indexer
 clusters remain Splunk-managed. `splunk-cloud-acs-allowlist-setup` is the
 Cloud-side control-plane workflow for ACS feature allowlists and does not map
 to an Enterprise runtime role.
+`splunk-admin-doctor` spans both Splunk Cloud and Splunk Enterprise as a
+diagnostic router: it renders reports, fix plans, and handoffs, but only applies
+the narrow safe fix packets exposed by its workflow.
+`splunk-cloud-data-manager-setup` stays Cloud-side and artifact-driven: it
+renders artifacts, runs doctor checks, validates, and safely applies supported
+Data Manager-generated AWS, Azure, GCP, and CrowdStrike onboarding artifacts
+without claiming private Data Manager API coverage.
 
 The biggest Cloud-specific limitation is hybrid collection architectures. For
 example, Splunk Stream on Splunk Cloud uses a cloud-hosted `splunk_app_stream`
@@ -1033,15 +1078,27 @@ follows a similar principle for SC4S: the repo prepares Splunk and renders the
 collector runtime assets, but the SC4S syslog-ng container itself runs on
 customer-managed infrastructure rather than on the Cloud search tier.
 `splunk-connect-for-snmp-setup` follows the same external-collector model for
-SC4SNMP polling and traps. `splunk-edge-processor-setup` also follows a
-customer-managed runtime model: it renders Edge Processor instance and pipeline
-assets that join to a Splunk Cloud tenant or Splunk Enterprise data management
-node, and emits ACS allowlist handoffs when Cloud destinations need them.
+SC4SNMP polling and traps. `splunk-connect-for-otlp-setup` follows the hybrid
+OTLP modular-input model: it can configure the Splunk Platform app where the
+listener can actually be reached, but Splunk Cloud Classic needs IDM or a
+customer-managed heavy forwarder, and Splunk Cloud Victoria still requires
+topology and inbound reachability validation before direct listener placement.
+`splunk-edge-processor-setup` also follows a customer-managed runtime model: it
+renders Edge Processor instance and pipeline assets that join to a Splunk Cloud
+tenant or Splunk Enterprise data management node, and emits ACS allowlist
+handoffs when Cloud destinations need them.
 `splunk-observability-otel-collector-setup` extends that pattern to
 customer-managed Kubernetes or Linux OpenTelemetry Collector runtimes that send
 data to Splunk Observability Cloud and optional Splunk Platform HEC. In these
 workflows, the rendered apply paths are rerunnable install-or-upgrade
 entrypoints for customer-managed runtimes.
+`splunk-observability-database-monitoring-setup` layers database receiver
+configuration for PostgreSQL, Microsoft SQL Server, and Oracle Database onto
+that collector model. `splunk-observability-ai-agent-monitoring-setup` renders
+GenAI instrumentation, evaluation telemetry, histogram collector readiness, and
+AI Infrastructure Monitoring handoffs. `splunk-observability-aws-integration`
+is an Observability Cloud API and IaC workflow for AWSCloudWatch polling and
+Metric Streams, not an AWS log-ingestion path.
 `splunk-observability-dashboard-builder` is separate from runtime placement: it
 renders and validates native Observability Cloud dashboard API payloads and can
 apply them only when explicitly requested.
@@ -1050,18 +1107,23 @@ for native Observability operations: it renders supported API payloads, API
 validation requests, deeplinks, and deterministic operator handoffs for UI-only
 surfaces. The Observability integration skills
 (`splunk-observability-cloud-integration-setup`,
+`splunk-observability-ai-agent-monitoring-setup`,
+`splunk-observability-database-monitoring-setup`,
 `splunk-observability-k8s-auto-instrumentation-setup`,
 `splunk-observability-k8s-frontend-rum-setup`,
+`splunk-observability-aws-integration`,
 `splunk-observability-thousandeyes-integration`,
 `splunk-observability-isovalent-integration`,
 `splunk-observability-cisco-nexus-integration`,
 `splunk-observability-cisco-intersight-integration`,
 `splunk-observability-nvidia-gpu-integration`, and
 `splunk-observability-cisco-ai-pod-integration`) follow the same render-first
-pattern: they overlay the base Splunk OTel Collector chart from
-`splunk-observability-otel-collector-setup`, pair with existing Splunk Platform
-TA skills where relevant, and hand off dashboards and detectors to
-`splunk-observability-dashboard-builder` and `splunk-observability-native-ops`.
+pattern: collector-dependent skills overlay the base Splunk OTel Collector
+chart from `splunk-observability-otel-collector-setup`; platform-pairing and
+cloud-service skills render API, IaC, or operator handoff payloads; and the
+skills hand off dashboards and detectors to
+`splunk-observability-dashboard-builder` and `splunk-observability-native-ops`
+where relevant.
 `splunk-enterprise-kubernetes-setup` is for self-managed Splunk Enterprise on
 Kubernetes: either Splunk Operator for Kubernetes on an existing cluster, or
 Splunk POD on Cisco UCS with the Splunk Kubernetes Installer.

--- a/SKILL_REQUIREMENTS.md
+++ b/SKILL_REQUIREMENTS.md
@@ -1,0 +1,128 @@
+# Skill Requirements
+
+This catalog documents the software and access requirements for each skill.
+Use it before running a skill so the operator can install the right local
+tools, prepare the right credentials files, and avoid discovering missing
+workflow dependencies halfway through an apply.
+
+## Shared Baseline
+
+All skills assume:
+
+- `bash`, `curl`, `python3`, and the repository root as the working directory.
+- A repo virtual environment with `pip install -r requirements-agent.txt` when
+  using the local MCP server or YAML-heavy Python renderers.
+- A local `credentials` file or `SPLUNK_CREDENTIALS_FILE`, mode `0600`, plus
+  separate secret files for tokens, passwords, API keys, and client secrets.
+- Splunk Enterprise management REST access on `8089`, or Splunk Cloud ACS plus
+  search-tier REST allow-list access, for live app install/configure/validate
+  workflows.
+- A Splunkbase/splunk.com account when the workflow downloads public Splunk
+  apps or TAs.
+
+Development and CI additionally require:
+
+- `pip install -r requirements-dev.txt -r requirements-agent.txt`
+- `bats`, `shellcheck`, `ruff`, `yamllint`, and `pre-commit` for the documented
+  local check suite.
+
+Environment-specific notes:
+
+- Run `duo-sso` before AWS live work in this environment.
+- Kubernetes apply/validate paths require the right `kubectl` or `oc` context.
+- Cloud and Observability tokens must be referenced by file path, never pasted
+  into shell arguments or chat.
+
+## Cisco Product And App Setup
+
+| Skill | Additional local tooling | Live access and product requirements |
+| --- | --- | --- |
+| `cisco-appdynamics-setup` | Shared baseline. | Splunk app workflow access; AppDynamics controller and analytics endpoint details; controller credentials/client secrets in files. |
+| `cisco-catalyst-enhanced-netflow-setup` | Shared baseline; Splunk Stream placement awareness. | Splunk app workflow access; existing Stream/IPFIX/HSL collection path and Catalyst data prerequisites. |
+| `cisco-catalyst-ta-setup` | Shared baseline. | Splunk app workflow access; Catalyst Center, ISE, SD-WAN, or Cyber Vision host/account details; device/API secrets in files. |
+| `cisco-dc-networking-setup` | Shared baseline. | Splunk app workflow access; ACI/APIC, Nexus Dashboard, or Nexus 9K account details; device/API secrets in files. |
+| `cisco-enterprise-networking-setup` | Shared baseline. | Splunk app workflow access; Cisco Enterprise Networking app installed; macro/index values for Catalyst/ISE dashboard searches. |
+| `cisco-intersight-setup` | Shared baseline. | Splunk app workflow access; Cisco Intersight account/API material stored in files. |
+| `cisco-isovalent-platform-setup` | `kubectl`, `helm`; optional `aws` for EKS helpers. | Kubernetes cluster-admin style access; Cilium/Tetragon chart access; Isovalent Enterprise chart/license/pull secret when using Enterprise mode. |
+| `cisco-meraki-ta-setup` | Shared baseline. | Splunk app workflow access; Meraki organization details and API key file. |
+| `cisco-product-setup` | Shared baseline. | SCAN catalog present; requirements inherit from the routed product setup skill. |
+| `cisco-scan-setup` | Shared baseline. | Splunk app workflow access; SCAN package/catalog sync access when refreshing the Cisco product catalog. |
+| `cisco-secure-access-setup` | Shared baseline. | Splunk app workflow access; Secure Access org/account details; event add-on prerequisites; client secrets in files. |
+| `cisco-secure-email-web-gateway-setup` | Shared baseline; SC4S or file-monitor handoff tools when using collector paths. | Splunk app workflow access; ESA/WSA source details; collector/index/macro placement decisions. |
+| `cisco-security-cloud-setup` | Shared baseline. | Splunk app workflow access; Cisco Security Cloud product variant details and input credentials in files. |
+| `cisco-spaces-setup` | Shared baseline. | Splunk app workflow access; Cisco Spaces account, firehose/meta stream details, and activation token file. |
+| `cisco-talos-intelligence-setup` | Shared baseline. | Splunk Enterprise Security Cloud readiness; Talos service account and capability mapping details. |
+| `cisco-thousandeyes-mcp-setup` | `node`, `npx`, `mcp-remote`; `codex` when registering Codex; `curl` for endpoint checks. | ThousandEyes MCP/API token material in files; target MCP clients available for registration. |
+| `cisco-thousandeyes-setup` | Shared baseline; `curl` for ThousandEyes/API checks. | Splunk app workflow access; ThousandEyes OAuth/account details; HEC and dashboard prerequisites. |
+| `cisco-ucs-ta-setup` | Shared baseline. | Splunk app workflow access; UCS Manager host/account details and password file. |
+| `cisco-webex-setup` | Shared baseline. | Splunk app workflow access; Webex OAuth app, scopes, organization IDs, and secret files. |
+
+## Collectors And Forwarders
+
+| Skill | Additional local tooling | Live access and product requirements |
+| --- | --- | --- |
+| `splunk-connect-for-otlp-setup` | Shared baseline. | Splunk app workflow access for app `8704`; HEC token/index readiness; OTLP sender endpoint details. |
+| `splunk-connect-for-snmp-setup` | `docker` or `podman` for Compose paths; `kubectl` and `helm` for Kubernetes paths. | HEC token/index readiness; SNMP polling/trap source details; Kubernetes or container host access. |
+| `splunk-connect-for-syslog-setup` | `docker` or `podman` for host paths; `kubectl` and `helm` for Kubernetes paths; `sudo` for system host setup. | HEC token/index readiness; syslog source/network port planning; Kubernetes or collector host access. |
+| `splunk-stream-setup` | Shared baseline. | Splunk app workflow access; Stream Forwarder host/network placement; packet capture or NetFlow/IPFIX source access. |
+| `splunk-universal-forwarder-setup` | `ssh`, `sudo`; `sshpass` for password-based remote bootstrap. | Target Linux/macOS/Windows hosts; Splunk package or Splunk Cloud credentials package; deployment server or indexer output details. |
+
+## Security And Response
+
+| Skill | Additional local tooling | Live access and product requirements |
+| --- | --- | --- |
+| `splunk-asset-risk-intelligence-setup` | Shared baseline. | Splunk app workflow access; ARI app package or Splunkbase access; KV Store and ES Exposure Analytics readiness. |
+| `splunk-attack-analyzer-setup` | Shared baseline. | Splunk app workflow access; Attack Analyzer app/add-on packages; `saa` index and API key handoff. |
+| `splunk-enterprise-security-config` | `PyYAML`; optional `ssh`, `scp`, and `sshpass` for package/content staging. | Splunk Enterprise Security REST access; ES app installed or install handoff permitted; lookup/threat/intel files supplied locally. |
+| `splunk-enterprise-security-install` | Optional `ssh` and `scp` for deployer/indexer staging; Bats/ShellCheck only for local tests. | ES package or Splunkbase access; search head or SHC deployer admin access; KV Store backup/restart permissions. |
+| `splunk-oncall-setup` | `PyYAML` for YAML specs. | Splunk On-Call API ID, API key file, REST endpoint integration key file, routing keys, and optional Splunk-side app workflow access. |
+| `splunk-security-essentials-setup` | Shared baseline. | Splunk app workflow access; Splunk Security Essentials package or Splunkbase access. |
+| `splunk-security-portfolio-setup` | Shared baseline. | Product routing access; requirements inherit from the selected ES, SOAR, SSE, UBA, Attack Analyzer, or ARI workflow. |
+| `splunk-soar-setup` | `docker` or `podman`; `systemctl`; optional `ssh`, `scp`, and `sudo` for remote/on-prem setup. | SOAR package or Cloud onboarding details; external PostgreSQL/GlusterFS/Elasticsearch details when clustering; Automation Broker host access. |
+| `splunk-uba-setup` | Shared baseline. | Splunk UBA/UEBA environment details; optional Kafka app placement; ES Premier UEBA migration context. |
+
+## Splunk Observability
+
+| Skill | Additional local tooling | Live access and product requirements |
+| --- | --- | --- |
+| `splunk-observability-ai-agent-monitoring-setup` | `PyYAML`; `kubectl` for Kubernetes runtime apply paths. | Splunk Observability realm and token files; GenAI application/runtime details; optional HEC/Log Observer Connect handoffs. |
+| `splunk-observability-aws-integration` | `aws`; optional `terraform`; `curl`. | Run `duo-sso` before AWS access here; Splunk Observability admin/user token files; AWS account/organization permissions for CloudWatch and Metric Streams. |
+| `splunk-observability-cisco-ai-pod-integration` | `kubectl` or `oc`, `helm`, `yq`; child-skill tools for Nexus, Intersight, NVIDIA, and OTel collector handoffs. | Splunk Observability token files; Cisco AI Pod cluster access; UCS/Nexus/NVIDIA/NIM/vLLM/storage endpoint details. |
+| `splunk-observability-cisco-intersight-integration` | `kubectl` or `oc`; optional `helm`, `jq`, `yq`, `openssl`, `nc` for live checks and troubleshooting. | Splunk Observability token files; Kubernetes namespace access; Intersight API credentials in a Kubernetes Secret. |
+| `splunk-observability-cisco-nexus-integration` | `kubectl`, `helm`, `yq`; optional `ssh` and `nc` for device checks. | Splunk Observability token files; Nexus/NX-OS device SSH credentials via Kubernetes Secret; collector cluster access. |
+| `splunk-observability-cloud-integration-setup` | `acs`, `curl`, `openssl`; optional `docker` for companion local checks. | Splunk Cloud/Enterprise REST access; Splunk Observability admin/org/user token files; Log Observer Connect and SIM add-on prerequisites. |
+| `splunk-observability-dashboard-builder` | `PyYAML` for YAML specs. | Splunk Observability API token file with dashboard permissions; target realm/org. |
+| `splunk-observability-database-monitoring-setup` | `kubectl`, `helm`; `PyYAML`. | Splunk Observability token files; database endpoint details; DB credentials in Kubernetes Secrets or local secret files. |
+| `splunk-observability-isovalent-integration` | `kubectl` or `oc`, `helm`, `yq`; optional `jq` and `aws`. | Splunk Observability token files; installed Cilium/Tetragon/Hubble stack; optional Splunk HEC token/index for Tetragon logs. |
+| `splunk-observability-k8s-auto-instrumentation-setup` | `kubectl`, `helm`; optional `npm` for app/runtime helper snippets. | Splunk Observability token files; OpenTelemetry Operator or Splunk OBI readiness; target workload namespaces. |
+| `splunk-observability-k8s-frontend-rum-setup` | `kubectl`; `npm` and `splunk-rum` for source-map helpers. | Splunk RUM token file; Splunk Observability token file for source maps; target frontend workload/ingress access. |
+| `splunk-observability-native-ops` | `PyYAML` for YAML specs. | Splunk Observability API token file with detector, alert-routing, synthetics, APM, RUM, or logs permissions; optional On-Call handoff. |
+| `splunk-observability-nvidia-gpu-integration` | `kubectl`, `helm`, `yq`. | Splunk Observability token files; NVIDIA GPU Operator or DCGM Exporter in the target cluster. |
+| `splunk-observability-otel-collector-setup` | `kubectl` and `helm` for Kubernetes; `ssh`, `scp`, `systemctl`, and `sudo` for Linux host apply; optional `npm` for generated helpers. | Splunk Observability realm/token files; target Kubernetes cluster or Linux host access; optional Splunk HEC token file for platform log export. |
+| `splunk-observability-thousandeyes-integration` | `curl`, optional `jq`; `codex` only for MCP/client handoff snippets. | ThousandEyes OAuth/API credentials in files; Splunk Observability token files; TE test/stream/template permissions. |
+
+## Splunk Platform Operations
+
+| Skill | Additional local tooling | Live access and product requirements |
+| --- | --- | --- |
+| `splunk-admin-doctor` | `acs` for Cloud checks; optional `ssh`; `curl`. | Splunk Cloud ACS or Enterprise REST access; admin-domain permissions for the areas being diagnosed. |
+| `splunk-agent-management-setup` | Shared baseline. | Splunk Enterprise deployment server or deployment-app file target access; server class/app ownership details. |
+| `splunk-ai-assistant-setup` | Shared baseline. | Splunk app workflow access; Splunk AI Assistant entitlement and activation/onboarding details. |
+| `splunk-app-install` | `acs`; optional `ssh`, `scp`, and `sshpass` for Enterprise remote staging. | Splunk Enterprise REST or Splunk Cloud ACS access; Splunkbase credentials or local package path. |
+| `splunk-cloud-acs-allowlist-setup` | `acs`; optional `terraform`; `curl` for source-IP discovery. | Splunk Cloud ACS stack permissions; exact allowlist feature/subnet plan; lock-out protection review. |
+| `splunk-cloud-data-manager-setup` | `aws`, `az`, `gcloud`, and `terraform` only for the cloud artifact families being validated/applied. | Data Manager-generated CloudFormation/ARM/Terraform artifacts; cloud-provider permissions; HEC/index prerequisites. |
+| `splunk-edge-processor-setup` | `docker` for local/container handoffs; `systemctl` for Linux service paths. | Splunk Cloud or Enterprise Edge Processor control-plane access; EP instance host permissions. |
+| `splunk-enterprise-host-setup` | `ssh`, `sudo`; package checksum tools from the host OS. | Target Linux hosts; Splunk Enterprise package access; role/topology settings for search/indexer/HF/cluster membership. |
+| `splunk-enterprise-kubernetes-setup` | `kubectl`, `helm`; `aws` for optional EKS kubeconfig helper. | Kubernetes cluster access; Splunk Operator for Kubernetes or Splunk POD installer/bastion access. |
+| `splunk-enterprise-public-exposure-hardening` | `openssl`, `nc`, `curl`; optional `aws`/ACS/firewall/WAF handoff tools. | On-prem Splunk Enterprise admin access; reverse proxy/firewall/WAF ownership; explicit public-exposure acceptance. |
+| `splunk-federated-search-setup` | `PyYAML`; `curl`. | Splunk Enterprise REST access for federated provider/index configuration; remote provider details and credentials files. |
+| `splunk-hec-service-setup` | Shared baseline. | Splunk Enterprise REST or Splunk Cloud ACS access; HEC index/token naming plan; HEC receiver URL decisions. |
+| `splunk-index-lifecycle-smartstore-setup` | Shared baseline. | Splunk Enterprise indexer or cluster-manager access; object store bucket/remote volume details and credentials handoff. |
+| `splunk-indexer-cluster-setup` | `ssh`, `scp`, `sudo`; `curl`. | Cluster manager/peer/search head admin access; bundle apply and rolling-restart authority. |
+| `splunk-itsi-config` | `PyYAML`; optional `ssh`, `scp`, and `sshpass` for content/file staging. | ITSI REST access; `SA-ITOA` and content-pack readiness; native object specs and ownership lookups. |
+| `splunk-itsi-setup` | Shared baseline. | Splunk app workflow access; ITSI package/Splunkbase entitlement and license readiness. |
+| `splunk-license-manager-setup` | `curl`; optional SSH/file-copy tooling for license file placement. | Splunk Enterprise license manager and peer admin access; license file(s) available locally. |
+| `splunk-mcp-server-setup` | `node`, `npm`/`npx`, `mcp-remote`; `codex` for Codex registration. | Splunk MCP Server app package/install access; Splunk bearer token file or token-minting permissions; target MCP clients. |
+| `splunk-monitoring-console-setup` | Shared baseline. | Splunk Enterprise Monitoring Console and peer REST access; distributed mode peer/group details. |
+| `splunk-platform-pki-setup` | `openssl`, `jq`; optional `ssh`, `scp`, and `sudo` for distribution/rotation handoffs. | Private CA or public CSR workflow inputs; per-component hostname/SAN inventory; Vault/AD CS/EJBCA/ACME handoffs when used. |
+| `splunk-workload-management-setup` | `systemctl` for local Linux readiness checks. | Splunk Enterprise workload-management capable hosts; Linux cgroup/systemd prerequisites; pool/rule/admission plan. |

--- a/agent/splunk_cisco_skills_mcp/core.py
+++ b/agent/splunk_cisco_skills_mcp/core.py
@@ -17,6 +17,7 @@ import subprocess
 import threading
 import time
 from collections import OrderedDict
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from threading import Lock
@@ -35,8 +36,32 @@ PLAN_HASH_CHARS = 64
 PLAN_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 DEFAULT_TIMEOUT_SECONDS = 1800
 MIN_TIMEOUT_SECONDS = 1
-MAX_TIMEOUT_SECONDS = int(os.environ.get("MCP_MAX_TIMEOUT_SECONDS", "7200"))
-RESOLVE_TIMEOUT_SECONDS = int(os.environ.get("MCP_RESOLVE_TIMEOUT_SECONDS", "60"))
+
+
+def _env_int(name: str, default: int, *, min_value: int | None = None) -> int:
+    """Read an integer env var without letting bad config crash import."""
+    raw_value = os.environ.get(name)
+    if raw_value in (None, ""):
+        return default
+    try:
+        value = int(raw_value)
+    except ValueError:
+        return default
+    if min_value is not None and value < min_value:
+        return default
+    return value
+
+
+MAX_TIMEOUT_SECONDS = _env_int(
+    "MCP_MAX_TIMEOUT_SECONDS",
+    7200,
+    min_value=MIN_TIMEOUT_SECONDS,
+)
+RESOLVE_TIMEOUT_SECONDS = _env_int(
+    "MCP_RESOLVE_TIMEOUT_SECONDS",
+    60,
+    min_value=MIN_TIMEOUT_SECONDS,
+)
 # Max characters of stdout/stderr returned per stream. The bounded subprocess
 # wrapper enforces this at the byte level during execution to prevent unbounded
 # memory growth from chatty scripts.
@@ -52,7 +77,7 @@ MAX_STORED_PLANS = 256
 # cannot be quietly applied later — the operator must regenerate the plan
 # from the current state. Override at deployment time with
 # MCP_PLAN_TTL_SECONDS=<int>; values <= 0 disable the TTL guard entirely.
-PLAN_TTL_SECONDS = int(os.environ.get("MCP_PLAN_TTL_SECONDS", "3600"))
+PLAN_TTL_SECONDS = _env_int("MCP_PLAN_TTL_SECONDS", 3600)
 
 # Scripts whose --dry-run / --list-products invocation is genuinely read-only.
 # Any (skill, script) pair NOT in this set is treated as mutating regardless of
@@ -536,6 +561,22 @@ def _safe_text(value: Any, *, label: str) -> str:
     return value
 
 
+def _safe_string_mapping(
+    value: Mapping[Any, Any] | None,
+    *,
+    label: str,
+) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise SkillMCPError(f"{label} must be an object of string keys and values")
+    safe: dict[str, str] = {}
+    for raw_key, raw_value in value.items():
+        key = _safe_text(raw_key, label=f"{label} key")
+        safe[key] = _safe_text(raw_value, label=f"{label}[{key}]")
+    return safe
+
+
 def _looks_secret_key(key: str) -> bool:
     if normalize_key := re.sub(r"[^A-Za-z0-9]+", "_", key).strip("_").lower():
         if normalize_key in NON_SECRET_VALUE_KEYS:
@@ -544,7 +585,7 @@ def _looks_secret_key(key: str) -> bool:
 
 
 def _validate_timeout(timeout_seconds: int) -> int:
-    if not isinstance(timeout_seconds, int):
+    if isinstance(timeout_seconds, bool) or not isinstance(timeout_seconds, int):
         raise SkillMCPError("timeout_seconds must be an integer")
     if timeout_seconds < MIN_TIMEOUT_SECONDS or timeout_seconds > MAX_TIMEOUT_SECONDS:
         raise SkillMCPError(
@@ -578,6 +619,8 @@ def _script_command(path: Path, args: list[str]) -> list[str]:
 
 
 def _validate_args(args: list[str]) -> list[str]:
+    if not isinstance(args, list):
+        raise SkillMCPError("args must be a list of strings")
     safe_args: list[str] = []
     index = 0
     while index < len(args):
@@ -589,6 +632,12 @@ def _validate_args(args: list[str]) -> list[str]:
             )
         if arg.startswith("--") and "=" in arg and flag in SECRET_FILE_FLAGS:
             path_value = arg.split("=", 1)[1]
+            if not path_value:
+                raise SkillMCPError(f"{flag} requires a file path")
+        elif flag in SECRET_FILE_FLAGS and flag != "--secret-file":
+            if index + 1 >= len(args):
+                raise SkillMCPError(f"{flag} requires a file path")
+            path_value = _safe_text(args[index + 1], label=f"{flag} path")
             if not path_value:
                 raise SkillMCPError(f"{flag} requires a file path")
         if arg == "--set":
@@ -770,13 +819,22 @@ def _run_command(command: list[str], *, timeout_seconds: int) -> _BoundedResult:
     while waiting for the timeout.
     """
     timeout_seconds = _validate_timeout(timeout_seconds)
-    proc = subprocess.Popen(
-        command,
-        cwd=REPO_ROOT,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=False,
-    )
+    try:
+        proc = subprocess.Popen(
+            command,
+            cwd=REPO_ROOT,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=False,
+            start_new_session=True,
+        )
+    except OSError as exc:
+        return _BoundedResult(
+            returncode=127,
+            stdout="",
+            stderr=f"Failed to start command: {exc}",
+        )
     stdout_buf: list[bytes] = []
     stderr_buf: list[bytes] = []
     stdout_dropped = [0]
@@ -798,14 +856,31 @@ def _run_command(command: list[str], *, timeout_seconds: int) -> _BoundedResult:
         returncode = proc.wait(timeout=timeout_seconds)
     except subprocess.TimeoutExpired:
         timed_out = True
-        # Send SIGTERM, then SIGKILL after a grace period if needed.
+        # Send SIGTERM, then SIGKILL after a grace period if needed. The
+        # child is started in a new session so this reaches subprocesses that
+        # inherited the script's process group as well as the shell itself.
         try:
-            proc.terminate()
+            os.killpg(proc.pid, signal.SIGTERM)
+        except (OSError, ProcessLookupError):
+            try:
+                proc.terminate()
+            except (OSError, ProcessLookupError):
+                pass
+        try:
             try:
                 returncode = proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
-                proc.kill()
-                returncode = proc.wait(timeout=5)
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except (OSError, ProcessLookupError):
+                    try:
+                        proc.kill()
+                    except (OSError, ProcessLookupError):
+                        pass
+                try:
+                    returncode = proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    returncode = -signal.SIGKILL
         except (OSError, ProcessLookupError):
             returncode = -signal.SIGKILL
     finally:
@@ -1215,8 +1290,8 @@ def plan_cisco_product_setup(
 ) -> dict[str, Any]:
     product = _safe_text(product, label="product")
     timeout_seconds = _validate_timeout(timeout_seconds)
-    set_values = set_values or {}
-    secret_files = secret_files or {}
+    set_values = _safe_string_mapping(set_values, label="set_values")
+    secret_files = _safe_string_mapping(secret_files, label="secret_files")
 
     phase_flags = {
         "full": [],
@@ -1317,7 +1392,7 @@ def plan_skill_script(
 ) -> dict[str, Any]:
     path = _script_path(skill, script)
     timeout_seconds = _validate_timeout(timeout_seconds)
-    safe_args = _validate_args(args or [])
+    safe_args = _validate_args([] if args is None else args)
     command = _script_command(path, safe_args)
     script_name = path.name
     pair = (skill, script_name)

--- a/tests/check_repo_readiness.py
+++ b/tests/check_repo_readiness.py
@@ -17,6 +17,7 @@ REQUIRED_TOP_LEVEL = [
     "SECURITY.md",
     "LICENSE",
     "CHANGELOG.md",
+    "SKILL_REQUIREMENTS.md",
     ".gitattributes",
     ".github/CODEOWNERS",
     ".github/pull_request_template.md",
@@ -131,6 +132,26 @@ def check_catalog_sync(errors: list[str]) -> None:
             errors.append(f"{rel}: missing skill catalog entries: {', '.join(missing)}")
         if extra:
             errors.append(f"{rel}: unknown skill catalog entries: {', '.join(extra)}")
+
+
+def check_skill_requirements_catalog(errors: list[str]) -> None:
+    doc_path = REPO_ROOT / "SKILL_REQUIREMENTS.md"
+    if not doc_path.exists():
+        return
+    expected = set(skill_names())
+    actual = catalog_skills(doc_path)
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    if missing:
+        errors.append(
+            "SKILL_REQUIREMENTS.md: missing skill requirement entries: "
+            + ", ".join(missing)
+        )
+    if extra:
+        errors.append(
+            "SKILL_REQUIREMENTS.md: unknown skill requirement entries: "
+            + ", ".join(extra)
+        )
 
 
 def check_cursor_and_claude_commands(errors: list[str]) -> None:
@@ -281,6 +302,7 @@ def main() -> int:
     errors: list[str] = []
     check_required_files(errors)
     check_catalog_sync(errors)
+    check_skill_requirements_catalog(errors)
     check_cursor_and_claude_commands(errors)
     check_no_tracked_local_artifacts(errors)
     check_secret_examples(errors)

--- a/tests/test_agent_mcp_core.py
+++ b/tests/test_agent_mcp_core.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import re
@@ -9,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 from agent.splunk_cisco_skills_mcp import core
 
@@ -132,6 +134,26 @@ class AgentMCPCoreTests(unittest.TestCase):
                 ["--password", "secret-value"],
             )
 
+    def test_generic_script_plan_requires_args_list(self) -> None:
+        with self.assertRaisesRegex(core.SkillMCPError, "args must be a list"):
+            core.plan_skill_script(
+                "cisco-product-setup",
+                "resolve_product.sh",
+                "--help",  # type: ignore[arg-type]
+            )
+
+    def test_product_plan_requires_mapping_inputs(self) -> None:
+        with self.assertRaisesRegex(core.SkillMCPError, "set_values must be an object"):
+            core.plan_cisco_product_setup(
+                "Cisco ACI",
+                set_values=["hostname", "apic1.example.local"],  # type: ignore[arg-type]
+            )
+        with self.assertRaisesRegex(core.SkillMCPError, "secret_files must be an object"):
+            core.plan_cisco_product_setup(
+                "Cisco ACI",
+                secret_files=["password", "/tmp/p"],  # type: ignore[arg-type]
+            )
+
     def test_generic_script_plan_rejects_oncall_direct_secret_flags(self) -> None:
         cases = [
             ["--oncall-api-key", "secret-value"],
@@ -166,6 +188,21 @@ class AgentMCPCoreTests(unittest.TestCase):
             with self.subTest(skill=skill, args=args):
                 with self.assertRaisesRegex(core.SkillMCPError, "Direct secret flag"):
                     core.plan_skill_script(skill, "setup.sh", args)
+
+    def test_generic_script_plan_requires_file_secret_paths(self) -> None:
+        cases = [
+            ["--password-file"],
+            ["--password-file", ""],
+            ["--token-file="],
+        ]
+        for args in cases:
+            with self.subTest(args=args):
+                with self.assertRaisesRegex(core.SkillMCPError, "requires a file path"):
+                    core.plan_skill_script(
+                        "cisco-catalyst-ta-setup",
+                        "configure_account.sh",
+                        args,
+                    )
 
     def test_oncall_setup_render_only_invocations_are_read_only(self) -> None:
         # No mutation flag → read-only.
@@ -435,6 +472,40 @@ class AgentMCPCoreTests(unittest.TestCase):
             core.execute_plan("not-a-hash", confirm=True)
         with self.assertRaisesRegex(core.SkillMCPError, "64-character lowercase hex"):
             core.execute_plan("A" * 64, confirm=True)
+
+    def test_timeout_rejects_bool(self) -> None:
+        with self.assertRaisesRegex(core.SkillMCPError, "timeout_seconds must be an integer"):
+            core.plan_skill_script(
+                "cisco-product-setup",
+                "resolve_product.sh",
+                ["--help"],
+                timeout_seconds=True,  # type: ignore[arg-type]
+            )
+
+    def test_invalid_integer_env_values_do_not_break_import(self) -> None:
+        env = os.environ.copy()
+        env["MCP_MAX_TIMEOUT_SECONDS"] = "not-an-int"
+        env["MCP_RESOLVE_TIMEOUT_SECONDS"] = "also-bad"
+        env["MCP_PLAN_TTL_SECONDS"] = "bad"
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "from agent.splunk_cisco_skills_mcp import core; "
+                    "print(core.MAX_TIMEOUT_SECONDS, core.RESOLVE_TIMEOUT_SECONDS, core.PLAN_TTL_SECONDS)"
+                ),
+            ],
+            cwd=core.REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(result.stdout.strip(), "7200 60 3600")
 
     def test_dry_run_flag_does_not_make_arbitrary_scripts_read_only(self) -> None:
         # A script that does not actually implement --dry-run must NOT be
@@ -965,6 +1036,38 @@ class AgentMCPCoreTests(unittest.TestCase):
         finally:
             if previous is not None:
                 os.environ["SPLUNK_SKILLS_MCP_ALLOW_MUTATION"] = previous
+
+    def test_run_command_isolates_stdin_and_process_group(self) -> None:
+        class FakeProc:
+            pid = 12345
+
+            def __init__(self) -> None:
+                self.stdout = io.BytesIO(b"ok\n")
+                self.stderr = io.BytesIO(b"")
+
+            def wait(self, timeout: int | None = None) -> int:
+                return 0
+
+        fake_proc = FakeProc()
+        with mock.patch.object(core.subprocess, "Popen", return_value=fake_proc) as popen:
+            result = core._run_command(["fake"], timeout_seconds=1)
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "ok\n")
+        kwargs = popen.call_args.kwargs
+        self.assertEqual(kwargs["stdin"], core.subprocess.DEVNULL)
+        self.assertTrue(kwargs["start_new_session"])
+
+    def test_run_command_returns_structured_error_when_spawn_fails(self) -> None:
+        with mock.patch.object(
+            core.subprocess,
+            "Popen",
+            side_effect=FileNotFoundError("missing-binary"),
+        ):
+            result = core._run_command(["missing-binary"], timeout_seconds=1)
+
+        self.assertEqual(result.returncode, 127)
+        self.assertIn("Failed to start command", result.stderr)
 
     def test_catalog_non_secret_keys_do_not_match_secret_regex(self) -> None:
         """Defense against future catalog edits.


### PR DESCRIPTION
## Summary

- Add `SKILL_REQUIREMENTS.md` with shared baseline requirements and per-skill local tooling/live-access requirements for all 69 skills.
- Link the new matrix from the README requirements section and refresh related skill catalog coverage for Splunk Connect for OTLP.
- Add repo-readiness coverage so every tracked skill must have a corresponding requirements entry.
- Harden the local skills MCP planning/runtime path around invalid env integers, timeout validation, typed inputs, file-secret arguments, subprocess stdin/process groups, and spawn errors.

## Why

The repo-level README minimum requirements were useful for the common path, but they did not tell operators which skills need Kubernetes tools, cloud CLIs, Node/MCP tooling, Terraform, Docker/Podman, `splunk-rum`, or live product access. This PR gives that coverage a durable place and adds a guard so new skills do not drift out of the requirements matrix.

## Validation

- `python3 tests/check_repo_readiness.py`
- `ruff check tests/check_repo_readiness.py agent/splunk_cisco_skills_mcp/core.py tests/test_agent_mcp_core.py`
- `.venv/bin/pytest -q tests/test_agent_mcp_core.py`

Earlier full audit run in this worktree also passed: `.venv/bin/pytest -q` (`1251 passed, 1 skipped`), `bats tests/*.bats`, `shellcheck --severity=warning $(find skills -name '*.sh' -print)`, `ruff check skills/ tests/ agent/`, `yamllint`, Bash syntax, SKILL frontmatter, repo readiness, and deployment-doc freshness.