### PR TITLE
Close coverage gaps in product router

### DIFF
--- a/skills/cisco-product-setup/catalog.json
+++ b/skills/cisco-product-setup/catalog.json
@@ -3048,7 +3048,13 @@
       "value_proposition": "Unified XDR visibility correlating alerts from endpoints, network, cloud, and email."
     },
     {
-      "accepted_non_secret_keys": [],
+      "accepted_non_secret_keys": [
+        "client_id",
+        "create_defaults",
+        "hostname",
+        "name",
+        "verify_ssl"
+      ],
       "addon": "",
       "addon_label": "",
       "addon_uid": "",
@@ -3057,7 +3063,7 @@
       "app_viz_2": "",
       "app_viz_label": "",
       "app_viz_uid": "",
-      "automation_state": "unsupported_roadmap",
+      "automation_state": "partial",
       "category": "networking",
       "companion_skills": [],
       "conditional_required_secret_rules": [],
@@ -3065,7 +3071,9 @@
       "description": "Hyperconverged infrastructure platform combining compute, storage, and networking into a unified cluster managed through Intersight or HX Connect. Runs the HX Data Platform for distributed storage with native replication, deduplication, and compression. Distinct from UCS (compute-only) \u2014 HyperFlex adds software-defined storage and can be managed via Intersight alongside UCS.",
       "display_name": "Cisco HyperFlex",
       "id": "cisco_hyperflex",
-      "install_apps": [],
+      "install_apps": [
+        "Splunk_TA_Cisco_Intersight"
+      ],
       "keywords": [
         "hyperflex",
         "hx",
@@ -3076,7 +3084,7 @@
         "hx connect"
       ],
       "learn_more_url": "https://www.cisco.com/site/us/en/products/computing/hyperconverged-infrastructure/index.html",
-      "manual_gap_reason": "This product is a roadmap / coverage-gap item in the SCAN catalog.",
+      "manual_gap_reason": "",
       "normalized_search_terms": [
         "cisco hyperflex",
         "hyperflex",
@@ -3087,15 +3095,25 @@
         "software defined storage",
         "hx connect"
       ],
-      "notes": "",
-      "optional_non_secret_keys": [],
+      "notes": "HyperFlex coverage is routed through the Cisco Intersight Add-on because the repo's Intersight workflow covers UCS and HyperFlex inventory, alarms, and metrics from the Intersight management plane.",
+      "optional_non_secret_keys": [
+        "hostname",
+        "create_defaults",
+        "verify_ssl"
+      ],
       "prereq_apps": [],
       "prereq_labels": [],
-      "primary_skill": "",
-      "required_non_secret_keys": [],
+      "primary_skill": "cisco-intersight-setup",
+      "required_non_secret_keys": [
+        "name",
+        "client_id"
+      ],
       "required_secret_keys": [],
-      "route": {},
-      "route_type": "",
+      "route": {
+        "default_index": "intersight",
+        "default_name": "INTERSIGHT_PROD"
+      },
+      "route_type": "intersight",
       "search_terms": [
         "cisco_hyperflex",
         "cisco hyperflex",
@@ -3108,12 +3126,20 @@
         "software defined storage",
         "hx connect"
       ],
-      "secret_keys": [],
+      "secret_keys": [
+        "client_secret"
+      ],
       "sourcetypes": [],
       "status": "roadmap",
       "subcategory": "compute_infra",
-      "template_checks": {},
-      "template_paths": [],
+      "template_checks": {
+        "ini_sections": [
+          "intersight_account"
+        ]
+      },
+      "template_paths": [
+        "skills/cisco-intersight-setup/template.example"
+      ],
       "value_proposition": "Ingest HyperFlex cluster health metrics, storage performance telemetry, replication status, and hardware alerts into Splunk for unified HCI operations monitoring alongside UCS and Intersight data."
     },
     {
@@ -3943,7 +3969,7 @@
       "app_viz_2": "",
       "app_viz_label": "",
       "app_viz_uid": "",
-      "automation_state": "unsupported_roadmap",
+      "automation_state": "partial",
       "category": "networking",
       "companion_skills": [],
       "conditional_required_secret_rules": [],
@@ -3971,7 +3997,7 @@
         "gnmi"
       ],
       "learn_more_url": "https://www.cisco.com/site/us/en/products/networking/sdwan-routers/network-convergence-system-5700-series/index.html",
-      "manual_gap_reason": "This product is a roadmap / coverage-gap item in the SCAN catalog.",
+      "manual_gap_reason": "",
       "normalized_search_terms": [
         "cisco iosxr platforms",
         "cisco ios xr platforms",
@@ -3992,15 +4018,22 @@
         "grpc",
         "gnmi"
       ],
-      "notes": "",
+      "notes": "The local cisco_os receiver skill explicitly supports IOS-XR devices, so the product router should expose it as a partial Observability handoff instead of leaving IOS-XR as an unrouted roadmap item.",
       "optional_non_secret_keys": [],
       "prereq_apps": [],
       "prereq_labels": [],
-      "primary_skill": "",
+      "primary_skill": "splunk-observability-cisco-nexus-integration",
       "required_non_secret_keys": [],
       "required_secret_keys": [],
-      "route": {},
-      "route_type": "",
+      "route": {
+        "handoff": "Use the Splunk Observability Cisco Nexus/cisco_os receiver workflow for IOS-XR system and interface metrics. This is metrics-only coverage, not a Splunk Platform TA for IOS-XR syslog or model-driven telemetry.",
+        "sourcetypes": [],
+        "workflow_scripts": [
+          "skills/splunk-observability-cisco-nexus-integration/scripts/setup.sh",
+          "skills/splunk-observability-cisco-nexus-integration/scripts/validate.sh"
+        ]
+      },
+      "route_type": "workflow_handoff",
       "search_terms": [
         "cisco_iosxr_platforms",
         "cisco iosxr platforms",

--- a/skills/cisco-product-setup/catalog_overrides.json
+++ b/skills/cisco-product-setup/catalog_overrides.json
@@ -154,6 +154,22 @@
       "automation_state": "no_plans_available",
       "manual_gap_reason": "This product is marked under_development in the packaged SCAN catalog and has no verified Splunk app, sourcetype, or local setup workflow in this repo yet."
     },
+    "cisco_hyperflex": {
+      "automation_state": "partial",
+      "route_type": "intersight",
+      "notes": "HyperFlex coverage is routed through the Cisco Intersight Add-on because the repo's Intersight workflow covers UCS and HyperFlex inventory, alarms, and metrics from the Intersight management plane."
+    },
+    "cisco_iosxr_platforms": {
+      "automation_state": "partial",
+      "route_type": "workflow_handoff",
+      "primary_skill": "splunk-observability-cisco-nexus-integration",
+      "workflow_scripts": [
+        "skills/splunk-observability-cisco-nexus-integration/scripts/setup.sh",
+        "skills/splunk-observability-cisco-nexus-integration/scripts/validate.sh"
+      ],
+      "handoff": "Use the Splunk Observability Cisco Nexus/cisco_os receiver workflow for IOS-XR system and interface metrics. This is metrics-only coverage, not a Splunk Platform TA for IOS-XR syslog or model-driven telemetry.",
+      "notes": "The local cisco_os receiver skill explicitly supports IOS-XR devices, so the product router should expose it as a partial Observability handoff instead of leaving IOS-XR as an unrouted roadmap item."
+    },
     "cisco_secure_access": {
       "route_type": "secure_access"
     },

--- a/skills/cisco-product-setup/scripts/setup.sh
+++ b/skills/cisco-product-setup/scripts/setup.sh
@@ -2119,7 +2119,11 @@ main() {
     resolve_product
     validate_known_keys
     prepare_effective_route
-    emit_role_warnings
+    if ${JSON_OUTPUT}; then
+        emit_role_warnings >&2
+    else
+        emit_role_warnings
+    fi
     if [[ "${AUTOMATION_STATE}" != "automated" ]]; then
         if ${JSON_OUTPUT}; then
             emit_summary_json

--- a/skills/splunk-ingest-processor-setup/scripts/validate.sh
+++ b/skills/splunk-ingest-processor-setup/scripts/validate.sh
@@ -2,6 +2,21 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    cat <<'USAGE'
+Usage: validate.sh [--help]
+
+Validate the Splunk Ingest Processor setup skill offline:
+  - syntax-check setup.sh and smoke_offline.sh
+  - compile render_assets.py
+  - run smoke_offline.sh
+
+This validation does not contact a Splunk tenant.
+USAGE
+    exit 0
+fi
+
 bash -n "${SCRIPT_DIR}/setup.sh"
 bash -n "${SCRIPT_DIR}/smoke_offline.sh"
 python3 -m py_compile "${SCRIPT_DIR}/render_assets.py"

--- a/skills/splunk-spl2-pipeline-kit/scripts/validate.sh
+++ b/skills/splunk-spl2-pipeline-kit/scripts/validate.sh
@@ -2,6 +2,21 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    cat <<'USAGE'
+Usage: validate.sh [--help]
+
+Validate the SPL2 pipeline kit offline:
+  - syntax-check setup.sh and smoke_offline.sh
+  - compile spl2_pipeline_kit.py
+  - run the built-in smoke profile
+
+This validation does not contact a Splunk tenant.
+USAGE
+    exit 0
+fi
+
 bash -n "${SCRIPT_DIR}/setup.sh"
 bash -n "${SCRIPT_DIR}/smoke_offline.sh"
 python3 -m py_compile "${SCRIPT_DIR}/spl2_pipeline_kit.py"

--- a/tests/test_cisco_product_setup.py
+++ b/tests/test_cisco_product_setup.py
@@ -467,6 +467,50 @@ version = {version}
         self.assertEqual(states["cisco_appomni"], "no_plans_available")
         self.assertEqual(states["cisco_radware"], "no_plans_available")
 
+    def test_hyperflex_routes_to_intersight_partial_handoff(self) -> None:
+        result = self.run_command(
+            "bash",
+            str(SETUP_SCRIPT),
+            "--catalog",
+            str(self.catalog_path),
+            "--product",
+            "Cisco HyperFlex",
+            "--dry-run",
+            "--json",
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["resolved_product"]["automation_state"], "partial")
+        self.assertEqual(payload["route"]["type"], "intersight")
+        self.assertEqual(payload["resolved_product"]["primary_skill"], "cisco-intersight-setup")
+        self.assertEqual(payload["install_apps"][0]["app_name"], "Splunk_TA_Cisco_Intersight")
+        self.assertIn("HyperFlex coverage is routed through", payload["resolved_product"]["notes"])
+
+    def test_iosxr_platforms_route_to_cisco_os_observability_handoff(self) -> None:
+        result = self.run_command(
+            "bash",
+            str(SETUP_SCRIPT),
+            "--catalog",
+            str(self.catalog_path),
+            "--product",
+            "Cisco IOS-XR Platforms",
+            "--dry-run",
+            "--json",
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["resolved_product"]["automation_state"], "partial")
+        self.assertEqual(payload["route"]["type"], "workflow_handoff")
+        self.assertEqual(
+            payload["resolved_product"]["primary_skill"],
+            "splunk-observability-cisco-nexus-integration",
+        )
+        self.assertIn("cisco_os receiver", payload["route"]["handoff"])
+        self.assertIn(
+            "skills/splunk-observability-cisco-nexus-integration/scripts/setup.sh",
+            payload["workflow_scripts"],
+        )
+
     def test_dry_run_secure_firewall_requires_variant(self) -> None:
         result = self.run_command(
             "bash",

--- a/tests/test_splunk_observability_deep_native_workflows.py
+++ b/tests/test_splunk_observability_deep_native_workflows.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Regression tests for Splunk Observability deep native workflow rendering."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.regression_helpers import REPO_ROOT
+
+
+SCRIPT_DIR = REPO_ROOT / "skills/splunk-observability-deep-native-workflows/scripts"
+TEMPLATE = REPO_ROOT / "skills/splunk-observability-deep-native-workflows/template.example"
+
+
+def test_deep_native_template_renders_coverage_packet(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_DIR / "render_workflows.py"),
+            "--spec",
+            str(TEMPLATE),
+            "--output-dir",
+            str(tmp_path),
+            "--realm",
+            "us0",
+            "--json",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["coverage_report"]["summary"]["api_apply"] >= 1
+    assert payload["coverage_report"]["summary"]["api_validate"] >= 1
+    assert payload["coverage_report"]["summary"]["handoff"] >= 1
+
+    surfaces = {
+        item["surface"]
+        for item in payload["coverage_report"]["objects"]
+    }
+    assert "modern_dashboard" in surfaces
+    assert "slo_creation" in surfaces
+    assert "rum_session_replay" in surfaces
+
+    for rel_path in (
+        "coverage-report.json",
+        "deeplinks.json",
+        "apply-plan.json",
+        "workflow-handoff.md",
+        "payloads/slo/checkout-request-success-slo.json",
+    ):
+        assert (tmp_path / rel_path).is_file()
+
+
+def test_deep_native_setup_rejects_inline_secret_flags() -> None:
+    result = subprocess.run(
+        [
+            "bash",
+            str(SCRIPT_DIR / "setup.sh"),
+            "--render",
+            "--spec",
+            str(TEMPLATE),
+            "--token",
+            "secret-value",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "would expose a secret in process listings" in result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- route Cisco HyperFlex to the existing Intersight partial handoff
- route Cisco IOS-XR platforms to the existing cisco_os Observability handoff
- keep JSON dry-run output parseable when role warnings are emitted
- add validation help paths and deep-native workflow regression coverage

## Local verification
- python3 skills/cisco-product-setup/scripts/build_catalog.py --check
- python3 tests/check_repo_readiness.py
- python3 tests/check_skill_frontmatter.py
- .venv/bin/python -m pytest tests/test_cisco_product_setup.py tests/test_splunk_observability_deep_native_workflows.py tests/test_skill_ux_catalog.py tests/test_cisco_splunkbase_product_coverage.py tests/test_skill_coverage_handoffs.py
- .venv/bin/python -m pytest (1490 passed, 3 skipped, before the final added deep-native regression)
