### PR TITLE
Fix Isovalent EKS validation workflow

### DIFF
--- a/skills/cisco-isovalent-platform-setup/SKILL.md
+++ b/skills/cisco-isovalent-platform-setup/SKILL.md
@@ -55,6 +55,7 @@ export:
   mode: file
   exportDirectory: /var/run/cilium/tetragon
   exportFilename: tetragon.log
+  exportFilePerm: "644"
 ```
 
 This is the **production-validated path** that coordinates with `splunk-observability-isovalent-integration`'s `agent.extraVolumes` hostPath mount and `logsCollection.extraFileLogs.filelog/tetragon` block. Override with `--export-mode stdout|fluentd` for users whose SCC/PSP policies block hostPath mounts (`stdout`) or who insist on the legacy fluentd `splunk_hec` output (`fluentd` — flagged DEPRECATED, the upstream `fluent-plugin-splunk-hec` was archived 2025-06-24).

--- a/skills/cisco-isovalent-platform-setup/scripts/render_assets.py
+++ b/skills/cisco-isovalent-platform-setup/scripts/render_assets.py
@@ -149,6 +149,7 @@ def tetragon_values(spec: dict[str, Any], edition: str, export_mode_override: st
         )
     export_directory = export_block.get("directory", "/var/run/cilium/tetragon")
     export_filename = export_block.get("filename", "tetragon.log")
+    export_file_perm = str(export_block.get("file_perm", "644"))
     enable_events = (overrides.get("enable_events") or {})
     base: dict[str, Any] = {
         "tetragon": {
@@ -158,6 +159,7 @@ def tetragon_values(spec: dict[str, Any], edition: str, export_mode_override: st
             },
             "exportDirectory": export_directory,
             "exportFilename": export_filename,
+            "exportFilePerm": export_file_perm,
         }
     }
     if export_mode == "file":

--- a/skills/cisco-isovalent-platform-setup/template.example
+++ b/skills/cisco-isovalent-platform-setup/template.example
@@ -61,6 +61,7 @@ tetragon:
     mode: file              # file (default) | stdout | fluentd
     directory: /var/run/cilium/tetragon
     filename: tetragon.log
+    file_perm: "644"        # allow the OTel collector hostPath reader to read exported files
 
 # Optional Tetragon TracingPolicy starter. The skill renders a basic
 # network-monitoring policy by default.

--- a/skills/splunk-observability-isovalent-integration/SKILL.md
+++ b/skills/splunk-observability-isovalent-integration/SKILL.md
@@ -64,10 +64,16 @@ This skill wires an installed Isovalent stack to Splunk Observability Cloud and 
 
 4. Apply the overlay onto the existing Splunk OTel collector helm release
    (recommended one-shot path). Merges this overlay onto current release
-   values via `yq`, runs `helm upgrade --atomic`, and rolls the agent +
-   cluster-receiver. Refuses without `--accept-k8s-apply`, refuses if no
-   Cilium/Tetragon install is detected, and prints the active kube-context
-   first:
+   values via `yq`, normalizes legacy `otlphttp` exporter names to
+   `otlp_http`, preserves the live OBI eBPF ConfigMap data when OBI is
+   installed, runs `helm upgrade --atomic --force-conflicts`, and rolls the agent +
+   cluster-receiver. The helper preserves existing gateway/operator topology
+   unless `collector.disable_gateway` or `collector.disable_operator` is set,
+   auto-discovers the collector namespace, and pins the installed chart version
+   unless `collector.namespace` or `collector.chart_version` is set in the spec.
+   Refuses without
+   `--accept-k8s-apply`, refuses if no Cilium/Tetragon install is detected,
+   and prints the active kube-context first:
 
    ```bash
    bash skills/splunk-observability-isovalent-integration/scripts/setup.sh \

--- a/skills/splunk-observability-isovalent-integration/reference.md
+++ b/skills/splunk-observability-isovalent-integration/reference.md
@@ -76,6 +76,8 @@ Alternatives:
 
 Rejected direct flags: `--access-token`, `--token`, `--bearer-token`, `--api-token`, `--o11y-token`, `--sf-token`, `--platform-hec-token`, `--hec-token`. Each error message points at the matching `--*-file` flag.
 
+`--apply` updates an existing Splunk OTel Collector Helm release. The rendered helper discovers the release namespace from Helm when `collector.namespace` is blank, pins the currently installed chart version when `collector.chart_version` is blank, preserves existing gateway/operator topology unless explicitly disabled in the spec, passes the O11y token with `--set-file`, preserves live OBI eBPF ConfigMap data when OBI is installed, reclaims known Helm ConfigMap fields that were previously patched with `kubectl`, normalizes legacy `otlphttp/...` component names in merged release values to the chart's `otlp_http/...` spelling when chart compatibility requires it, and runs Helm with `--force-conflicts` for server-side apply conflict recovery.
+
 ## Hand-offs
 
 - Splunk OTel Collector base install: [splunk-observability-otel-collector-setup](../splunk-observability-otel-collector-setup/SKILL.md) (rendered command in `handoff-base-collector.sh`).

--- a/skills/splunk-observability-isovalent-integration/references/tetragon-hostpath-coordination.md
+++ b/skills/splunk-observability-isovalent-integration/references/tetragon-hostpath-coordination.md
@@ -64,7 +64,7 @@ ERROR: extraFileLogs include (/var/log/tetragon/*.log) is not under hostPath (/v
 The Splunk OTel collector ServiceAccount needs read permission on the hostPath. This is usually fine because:
 
 - The collector agent runs as root by default in the Splunk OTel chart (root inside the container; node hostPath access governed by kernel).
-- Tetragon writes log files with mode 0644 by default.
+- `cisco-isovalent-platform-setup` renders `tetragon.exportFilePerm: "644"` for file mode. The upstream Tetragon chart default is stricter (`600`), which blocks a separate OTel collector process from reading the hostPath files.
 - OpenShift's `anyuid` SCC is required for the collector to read the hostPath as root (the platform-setup skill renders the SCC helper if `distribution: openshift`).
 
 If the collector runs as non-root (chart override), Tetragon's log file mode + ownership must be adjusted. This is an edge case and the skill does not currently render guidance for it; see `references/troubleshooting.md` if you hit it.

--- a/skills/splunk-observability-isovalent-integration/scripts/render_assets.py
+++ b/skills/splunk-observability-isovalent-integration/scripts/render_assets.py
@@ -155,6 +155,7 @@ def overlay_values(
     legacy_fluentd: bool,
     platform_hec_url: str,
 ) -> dict[str, Any]:
+    collector = spec.get("collector") or {}
     scrape = spec.get("scrape") or {}
     metric_allowlist = list(DEFAULT_METRIC_ALLOWLIST)
     extras = (spec.get("metric_allowlist") or {}).get("extra") or []
@@ -203,12 +204,6 @@ def overlay_values(
     overlay: dict[str, Any] = {
         "clusterName": cluster_name or "lab-cluster",
         "distribution": distribution or "kubernetes",
-        # Subtractive overrides for the Isovalent profile: we typically want
-        # the gateway off (collector pushes direct to O11y) and operator off
-        # (Isovalent uses its own CRDs; the OTel operator would conflict).
-        "operator": {"enabled": False},
-        "operatorcrds": {"installed": False},
-        "gateway": {"enabled": False},
         # OpenShift requires kubeletstats to skip TLS verify (self-signed kubelet
         # certs). Other distributions accept this default safely.
         "agent": {
@@ -248,6 +243,11 @@ def overlay_values(
             }
         },
     }
+    if collector.get("disable_gateway", False):
+        overlay["gateway"] = {"enabled": False}
+    if collector.get("disable_operator", False):
+        overlay["operator"] = {"enabled": False}
+        overlay["operatorcrds"] = {"installed": False}
 
     splunk_block = spec.get("splunk_platform") or {}
     if splunk_block.get("enabled", True) and export_mode == "file" and not legacy_fluentd:
@@ -259,6 +259,18 @@ def overlay_values(
         # production-validated path (see references/tetragon-hostpath-coordination.md).
         overlay["agent"]["extraVolumes"] = [{"name": "tetragon", "hostPath": {"path": host_path}}]
         overlay["agent"]["extraVolumeMounts"] = [{"name": "tetragon", "mountPath": host_path}]
+        overlay["agent"]["config"]["receivers"]["filelog/tetragon"] = {
+            "include": [f"{host_path}/{filename_pattern}"],
+            "start_at": "beginning",
+            "include_file_path": True,
+            "include_file_name": False,
+            "resource": {
+                "com.splunk.index": index,
+                "com.splunk.source": f"{host_path}/",
+                "host.name": 'EXPR(env("K8S_NODE_NAME"))',
+                "com.splunk.sourcetype": sourcetype,
+            },
+        }
         overlay["splunkPlatform"] = {
             "logsEnabled": True,
         }
@@ -319,7 +331,8 @@ def _scrape_job(name: str, app_label: str, port: int, label_key: str) -> dict[st
                         {
                             "source_labels": ["__meta_kubernetes_pod_ip"],
                             "target_label": "__address__",
-                            "replacement": "${__meta_kubernetes_pod_ip}:" + str(port),
+                            "regex": "(.+)",
+                            "replacement": "$1:" + str(port),
                         },
                         {"target_label": "job", "replacement": name},
                     ],
@@ -353,7 +366,8 @@ def _scrape_job_operator(name: str, port: int) -> dict[str, Any]:
                         {
                             "source_labels": ["__meta_kubernetes_pod_ip"],
                             "target_label": "__address__",
-                            "replacement": "${__meta_kubernetes_pod_ip}:" + str(port),
+                            "regex": "(.+)",
+                            "replacement": "$1:" + str(port),
                         },
                         {"target_label": "job", "replacement": name},
                     ],
@@ -382,7 +396,8 @@ def _scrape_job_tetragon(name: str, port: int) -> dict[str, Any]:
                         {
                             "source_labels": ["__meta_kubernetes_pod_ip"],
                             "target_label": "__address__",
-                            "replacement": "${__meta_kubernetes_pod_ip}:" + str(port),
+                            "regex": "(.+)",
+                            "replacement": "$1:" + str(port),
                         },
                         {"target_label": "job", "replacement": name},
                     ],
@@ -411,7 +426,8 @@ def _scrape_job_tetragon_operator(name: str, port: int) -> dict[str, Any]:
                         {
                             "source_labels": ["__meta_kubernetes_pod_ip"],
                             "target_label": "__address__",
-                            "replacement": "${__meta_kubernetes_pod_ip}:" + str(port),
+                            "regex": "(.+)",
+                            "replacement": "$1:" + str(port),
                         },
                         {"target_label": "job", "replacement": name},
                     ],
@@ -485,8 +501,10 @@ if __name__ == "__main__":
 def render_apply_overlay_script(spec: dict[str, Any]) -> str:
     collector = spec.get("collector") or {}
     release = collector.get("release", "splunk-otel-collector")
-    namespace = collector.get("namespace", "splunk-otel")
+    namespace = collector.get("namespace", "")
     chart_ref = collector.get("chart_ref", "splunk-otel-collector-chart/splunk-otel-collector")
+    chart_version = collector.get("chart_version", "")
+    normalize_legacy_otlphttp = str(collector.get("normalize_legacy_otlphttp", "auto")).lower()
     return (
         f"""#!/usr/bin/env bash
 set -euo pipefail
@@ -507,6 +525,16 @@ if [[ -z "${{O11Y_TOKEN_FILE:-}}" || ! -r "${{O11Y_TOKEN_FILE}}" ]]; then
     echo 'ERROR: O11Y_TOKEN_FILE must point to a readable token file (chmod 600).' >&2
     exit 1
 fi
+TOKEN_MODE=""
+if TOKEN_MODE="$(stat -f '%A' "${{O11Y_TOKEN_FILE}}" 2>/dev/null)"; then
+    :
+elif TOKEN_MODE="$(stat -c '%a' "${{O11Y_TOKEN_FILE}}" 2>/dev/null)"; then
+    :
+fi
+if [[ "${{TOKEN_MODE}}" != "600" && "${{TOKEN_MODE}}" != "0600" ]]; then
+    echo "ERROR: O11Y_TOKEN_FILE must be mode 600; got ${{TOKEN_MODE:-unknown}}." >&2
+    exit 1
+fi
 
 # Confirm Cilium / Tetragon presence; refuse to proceed if neither is found.
 if ! kubectl get ns cilium >/dev/null 2>&1 \\
@@ -523,29 +551,90 @@ OVERLAY="${{DIR}}/splunk-otel-overlay/values.overlay.yaml"
 RELEASE="{release}"
 NAMESPACE="{namespace}"
 CHART_REF="{chart_ref}"
+CHART_VERSION="{chart_version}"
+NORMALIZE_OTLPHTTP="{normalize_legacy_otlphttp}"
+export RELEASE
+if [[ -z "${{NAMESPACE}}" ]]; then
+    NAMESPACE="$(helm list --all-namespaces --filter "^${{RELEASE}}$" -o json 2>/dev/null | yq -r '.[] | select(.name == env(RELEASE)) | .namespace' - | head -1)"
+fi
+if [[ -z "${{NAMESPACE}}" ]]; then
+    NAMESPACE="splunk-otel"
+fi
+if [[ -z "${{CHART_VERSION}}" ]]; then
+    CHART_NAME="${{CHART_REF##*/}}"
+    INSTALLED_CHART="$(helm list --namespace "${{NAMESPACE}}" --filter "^${{RELEASE}}$" -o json 2>/dev/null | yq -r '.[] | select(.name == env(RELEASE)) | .chart' - | head -1)"
+    if [[ "${{INSTALLED_CHART}}" == "${{CHART_NAME}}-"* ]]; then
+        CHART_VERSION="${{INSTALLED_CHART#${{CHART_NAME}}-}}"
+    fi
+fi
 
 TMPDIR_LOCAL="$(mktemp -d)"
 trap 'rm -rf "${{TMPDIR_LOCAL}}"' EXIT
 helm get values "${{RELEASE}}" -n "${{NAMESPACE}}" -o yaml > "${{TMPDIR_LOCAL}}/current-values.yaml"
 yq eval-all '. as $i ireduce ({{}}; . * $i)' "${{TMPDIR_LOCAL}}/current-values.yaml" "${{OVERLAY}}" > "${{TMPDIR_LOCAL}}/merged.yaml"
+if kubectl -n "${{NAMESPACE}}" get configmap "${{RELEASE}}-obi" >/dev/null 2>&1; then
+    kubectl -n "${{NAMESPACE}}" get configmap "${{RELEASE}}-obi" -o jsonpath='{{.data.ebpf-instrument-config\\.yml}}' > "${{TMPDIR_LOCAL}}/obi-config.yaml"
+    if [[ -s "${{TMPDIR_LOCAL}}/obi-config.yaml" ]]; then
+        OBI_CONFIG_FILE="${{TMPDIR_LOCAL}}/obi-config.yaml" yq eval '.obi.config.data = load(strenv(OBI_CONFIG_FILE))' -i "${{TMPDIR_LOCAL}}/merged.yaml"
+    fi
+fi
+if kubectl -n "${{NAMESPACE}}" get configmap "${{RELEASE}}-otel-collector" >/dev/null 2>&1; then
+    kubectl -n "${{NAMESPACE}}" get configmap "${{RELEASE}}-otel-collector" -o jsonpath='{{.data.relay}}' > "${{TMPDIR_LOCAL}}/gateway-relay.yaml"
+    if [[ -s "${{TMPDIR_LOCAL}}/gateway-relay.yaml" ]]; then
+        GATEWAY_CONFIG_FILE="${{TMPDIR_LOCAL}}/gateway-relay.yaml" yq eval '.gateway.config = load(strenv(GATEWAY_CONFIG_FILE))' -i "${{TMPDIR_LOCAL}}/merged.yaml"
+    fi
+fi
+if [[ "${{NORMALIZE_OTLPHTTP}}" == "auto" ]]; then
+    case "${{CHART_VERSION}}" in
+        0.150.*|0.15[1-9].*|0.[2-9]*|[1-9]*) NORMALIZE_OTLPHTTP="true" ;;
+        *) NORMALIZE_OTLPHTTP="false" ;;
+    esac
+fi
+if [[ "${{NORMALIZE_OTLPHTTP}}" == "true" ]]; then
+    yq eval '
+      (.. | select(tag == "!!map")) |= with_entries(.key |= sub("^otlphttp"; "otlp_http")) |
+      (.. | select(tag == "!!str")) |= sub("^otlphttp"; "otlp_http")
+    ' "${{TMPDIR_LOCAL}}/merged.yaml" > "${{TMPDIR_LOCAL}}/merged.normalized.yaml"
+    mv "${{TMPDIR_LOCAL}}/merged.normalized.yaml" "${{TMPDIR_LOCAL}}/merged.yaml"
+fi
+
+claim_configmap_for_helm() {{
+    local name="${{1:?configmap name required}}" manifest
+    if ! kubectl -n "${{NAMESPACE}}" get configmap "${{name}}" >/dev/null 2>&1; then
+        return 0
+    fi
+    manifest="${{TMPDIR_LOCAL}}/${{name}}.claim.yaml"
+    kubectl -n "${{NAMESPACE}}" get configmap "${{name}}" -o yaml | yq eval 'del(.metadata.managedFields, .metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .metadata.selfLink, .status)' - > "${{manifest}}"
+    kubectl apply --server-side --force-conflicts --field-manager=helm -f "${{manifest}}" >/dev/null
+}}
 
 DRY_RUN_FLAG=()
 if [[ "${{K8S_APPLY_DRY_RUN:-false}}" == "true" ]]; then
     DRY_RUN_FLAG=(--dry-run)
     echo "DRY-RUN MODE: passing --dry-run to helm"
 fi
+if [[ "${{K8S_APPLY_DRY_RUN:-false}}" != "true" ]]; then
+    claim_configmap_for_helm "${{RELEASE}}-obi"
+    claim_configmap_for_helm "${{RELEASE}}-otel-collector"
+fi
+VERSION_FLAG=()
+if [[ -n "${{CHART_VERSION}}" ]]; then
+    VERSION_FLAG=(--version "${{CHART_VERSION}}")
+fi
 
 helm upgrade --install "${{RELEASE}}" "${{CHART_REF}}" \\
     --namespace "${{NAMESPACE}}" \\
+    "${{VERSION_FLAG[@]}}" \\
     --values "${{TMPDIR_LOCAL}}/merged.yaml" \\
-    --set "splunkObservability.accessToken=$(cat "${{O11Y_TOKEN_FILE}}")" \\
+    --set-file "splunkObservability.accessToken=${{O11Y_TOKEN_FILE}}" \\
+    --force-conflicts \\
     --atomic \\
     --timeout 5m \\
     "${{DRY_RUN_FLAG[@]}}"
 
 if [[ "${{K8S_APPLY_DRY_RUN:-false}}" != "true" ]]; then
     kubectl -n "${{NAMESPACE}}" rollout status daemonset/${{RELEASE}}-agent --timeout=180s || true
-    kubectl -n "${{NAMESPACE}}" rollout status deployment/${{RELEASE}}-cluster-receiver --timeout=180s || true
+    kubectl -n "${{NAMESPACE}}" rollout status deployment/${{RELEASE}}-k8s-cluster-receiver --timeout=180s || true
 fi
 """
     )

--- a/skills/splunk-observability-isovalent-integration/scripts/setup.sh
+++ b/skills/splunk-observability-isovalent-integration/scripts/setup.sh
@@ -189,7 +189,9 @@ RENDER_ARGS=(
     --o11y-token-file "${O11Y_TOKEN_FILE}"
     --dashboards-source "${DASHBOARDS_SOURCE}"
 )
-if [[ "${DRY_RUN}" == "true" ]]; then RENDER_ARGS+=(--dry-run); fi
+# A render-only dry-run should not write files. An apply dry-run still needs
+# fresh rendered assets; only the Kubernetes/Helm mutation is dry-run.
+if [[ "${DRY_RUN}" == "true" && "${MODE_APPLY}" != "true" ]]; then RENDER_ARGS+=(--dry-run); fi
 if [[ "${JSON_OUTPUT}" == "true" ]]; then RENDER_ARGS+=(--json); fi
 
 if [[ "${MODE_RENDER}" == "true" ]]; then

--- a/skills/splunk-observability-isovalent-integration/scripts/validate.sh
+++ b/skills/splunk-observability-isovalent-integration/scripts/validate.sh
@@ -114,6 +114,18 @@ print(inc[0] if inc else '')
             exit 1
         fi
     fi
+    FILELOG_RECEIVER="$(PYTHONPATH="${PROJECT_ROOT}/skills/shared/lib${PYTHONPATH:+:${PYTHONPATH}}" python3 -c "
+import sys
+from pathlib import Path
+from yaml_compat import load_yaml_or_json
+data = load_yaml_or_json(Path(sys.argv[1]).read_text(encoding='utf-8'), source=sys.argv[1])
+receiver = data.get('agent', {}).get('config', {}).get('receivers', {}).get('filelog/tetragon')
+print('present' if receiver else '')
+" "${OUTPUT_DIR}/splunk-otel-overlay/values.overlay.yaml")"
+    if [[ -n "${LOG_INCLUDE}" && "${FILELOG_RECEIVER}" != "present" ]]; then
+        log "ERROR: logsCollection references filelog/tetragon but agent.config.receivers.filelog/tetragon is missing."
+        exit 1
+    fi
 fi
 
 # Dashboards: every JSON in dashboards/ must parse cleanly and not contain

--- a/skills/splunk-observability-isovalent-integration/template.example
+++ b/skills/splunk-observability-isovalent-integration/template.example
@@ -16,6 +16,18 @@ realm: us0
 cluster_name: "lab-cluster"
 distribution: openshift  # openshift | kubernetes | eks | gke
 
+# Existing Splunk OTel Collector Helm release to update during --apply.
+# Leave namespace/chart_version blank to auto-discover from the installed
+# release and avoid an accidental chart upgrade.
+collector:
+  release: splunk-otel-collector
+  namespace: ""
+  chart_ref: splunk-otel-collector-chart/splunk-otel-collector
+  chart_version: ""
+  normalize_legacy_otlphttp: auto  # auto | true | false; auto enables for chart >= 0.150
+  disable_gateway: false
+  disable_operator: false
+
 # Splunk Platform target identity for the Tetragon log path.
 splunk_platform:
   enabled: true

--- a/tests/test_cisco_isovalent_platform_setup.py
+++ b/tests/test_cisco_isovalent_platform_setup.py
@@ -91,6 +91,7 @@ def test_tetragon_default_export_mode_file(tmp_path: Path) -> None:
     tetragon = (output / "helm/tetragon-values.yaml").read_text(encoding="utf-8")
     assert "exportDirectory: /var/run/cilium/tetragon" in tetragon
     assert "exportFilename: tetragon.log" in tetragon
+    assert "exportFilePerm: '644'" in tetragon
 
 
 def test_legacy_fluentd_emits_deprecation_warning(tmp_path: Path) -> None:

--- a/tests/test_splunk_observability_isovalent_integration.py
+++ b/tests/test_splunk_observability_isovalent_integration.py
@@ -97,7 +97,11 @@ def test_render_produces_overlay_and_handoffs(tmp_path: Path) -> None:
     assert "prometheus/isovalent_cilium" in overlay
     assert "prometheus/isovalent_hubble" in overlay
     assert "prometheus/isovalent_tetragon" in overlay
+    assert "${__meta_kubernetes_pod_ip}" not in overlay
+    assert "replacement: $1:" in overlay
     assert "filter/includemetrics" in overlay
+    assert "\ngateway:" not in f"\n{overlay}"
+    assert "\noperator:" not in f"\n{overlay}"
 
 
 def test_default_file_path_renders_extra_file_logs_aligned_with_hostpath(tmp_path: Path) -> None:
@@ -110,6 +114,7 @@ def test_default_file_path_renders_extra_file_logs_aligned_with_hostpath(tmp_pat
     assert "extraVolumes" in overlay
     assert "/var/run/cilium/tetragon" in overlay
     assert "filelog/tetragon" in overlay
+    assert "receivers:" in overlay
     assert "com.splunk.sourcetype: cisco:isovalent" in overlay
     assert "com.splunk.index: cisco_isovalent" in overlay
 
@@ -186,6 +191,65 @@ def test_handoff_to_cisco_security_cloud(tmp_path: Path) -> None:
     # Negative: confirm we do NOT emit the legacy/wrong --product flag that was
     # never a valid cisco-security-cloud-setup CLI argument.
     assert "--product isovalent" not in handoff
+
+
+def test_apply_helper_auto_discovers_collector_namespace_and_uses_set_file(tmp_path: Path) -> None:
+    """The apply helper must work with non-default collector namespaces.
+
+    Live EKS clusters commonly install the Splunk OTel Collector outside the
+    chart's example `splunk-otel` namespace. The helper should discover the
+    release namespace when the spec does not pin one, and it must not expand
+    the O11y token into the Helm process argv.
+    """
+    output = tmp_path / "rendered"
+    spec = write_spec(tmp_path / "spec.json")
+    result = run_setup("--render", "--spec", str(spec), "--output-dir", str(output))
+    assert result.returncode == 0, combined_output(result)
+    helper = (output / "scripts/apply-isovalent-overlay.sh").read_text(encoding="utf-8")
+    assert 'helm list --all-namespaces --filter "^${RELEASE}$" -o json' in helper
+    assert 'CHART_VERSION="${INSTALLED_CHART#${CHART_NAME}-}"' in helper
+    assert '"${VERSION_FLAG[@]}"' in helper
+    assert 'NAMESPACE="splunk-otel"' in helper
+    assert 'get configmap "${RELEASE}-obi"' in helper
+    assert ".obi.config.data = load(strenv(OBI_CONFIG_FILE))" in helper
+    assert 'get configmap "${RELEASE}-otel-collector"' in helper
+    assert ".gateway.config = load(strenv(GATEWAY_CONFIG_FILE))" in helper
+    assert "claim_configmap_for_helm" in helper
+    assert "claim_configmap_for_helm \"${RELEASE}-obi\"" in helper
+    assert "claim_configmap_for_helm \"${RELEASE}-otel-collector\"" in helper
+    assert 'if TOKEN_MODE="$(stat -f' in helper
+    assert 'elif TOKEN_MODE="$(stat -c' in helper
+    assert '|| stat -c' not in helper
+    assert 'NORMALIZE_OTLPHTTP="auto"' in helper
+    assert 'sub("^otlphttp"; "otlp_http")' in helper
+    assert "--force-conflicts" in helper
+    assert "--set-file \"splunkObservability.accessToken=${O11Y_TOKEN_FILE}\"" in helper
+    assert "deployment/${RELEASE}-k8s-cluster-receiver" in helper
+    assert "deployment/${RELEASE}-cluster-receiver" not in helper
+    assert '--set "splunkObservability.accessToken=$(cat "${O11Y_TOKEN_FILE}")"' not in helper
+
+
+def test_apply_helper_honors_explicit_collector_namespace(tmp_path: Path) -> None:
+    output = tmp_path / "rendered"
+    spec = write_spec(
+        tmp_path / "spec.json",
+        collector={
+            "release": "custom-collector",
+            "namespace": "otel-splunk",
+            "chart_version": "0.148.0",
+        },
+    )
+    result = run_setup("--render", "--spec", str(spec), "--output-dir", str(output))
+    assert result.returncode == 0, combined_output(result)
+    helper = (output / "scripts/apply-isovalent-overlay.sh").read_text(encoding="utf-8")
+    assert 'RELEASE="custom-collector"' in helper
+    assert 'NAMESPACE="otel-splunk"' in helper
+    assert 'CHART_VERSION="0.148.0"' in helper
+
+
+def test_apply_dry_run_still_renders_fresh_assets() -> None:
+    setup = SETUP.read_text(encoding="utf-8")
+    assert '[[ "${DRY_RUN}" == "true" && "${MODE_APPLY}" != "true" ]]' in setup
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Preserve live Splunk OTel collector gateway/operator configuration while applying the Isovalent integration overlay.
- Render explicit Tetragon filelog receiver configuration and validate that generated collector config is internally consistent.
- Fix Prometheus relabel replacements, chart-version handling, Helm ownership adoption, dry-run rendering, and Tetragon file export permissions for EKS validation.

## Validation
- `pytest -q tests/test_cisco_isovalent_platform_setup.py tests/test_splunk_observability_isovalent_integration.py` -> 28 passed
- Applied the rendered Splunk Observability Isovalent integration overlay to EKS cluster `isovalent-demo` and validated collector rollout.
- Live validation passed for Cilium, Hubble, Envoy, Cilium operator, Tetragon, Tetragon operator, and Cilium DNS proxy endpoints.
- Reconciled Tetragon file export permissions with `tetragon.exportFilePerm=644` and validated the platform skill live.