### PR TITLE
[codex] Add TA completion gate for ingest and dashboards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,12 @@ instructions. If more detail is needed, also read `skills/<skill-name>/reference
 
 The user can also invoke skills directly as slash commands (e.g. `/cisco-catalyst-ta-setup`).
 
+For any Splunk TA, add-on, or dashboard companion workflow, do not treat
+package install alone as successful setup. Follow
+`skills/shared/ta_completion_gate.md`: configure and validate data ingest, then
+verify shipped dashboards are visible, macro-aligned, and returning data, or
+record explicit evidence that the package ships no pre-built dashboards.
+
 ## Skill Catalog
 
 | Skill | Target | Main purpose |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,12 @@ instructions. If more detail is needed, also read `skills/<skill-name>/reference
 
 The user can also invoke skills directly as slash commands (e.g. `/cisco-catalyst-ta-setup`).
 
+For any Splunk TA, add-on, or dashboard companion workflow, do not treat
+package install alone as successful setup. Follow
+`skills/shared/ta_completion_gate.md`: configure and validate data ingest, then
+verify shipped dashboards are visible, macro-aligned, and returning data, or
+record explicit evidence that the package ships no pre-built dashboards.
+
 ## Skill Catalog
 
 | Skill | Target | Main purpose |

--- a/SKILL_REQUIREMENTS.md
+++ b/SKILL_REQUIREMENTS.md
@@ -34,6 +34,10 @@ Environment-specific notes:
 - Kubernetes apply/validate paths require the right `kubectl` or `oc` context.
 - Cloud and Observability tokens must be referenced by file path, never pasted
   into shell arguments or chat.
+- Splunk TA, add-on, and dashboard companion setup skills must satisfy the
+  shared `skills/shared/ta_completion_gate.md`: data ingest must be configured
+  and validated, and any pre-built dashboards must be visible, macro-aligned,
+  and returning data, or explicitly documented as not shipped by the package.
 
 ## Cisco Product And App Setup
 

--- a/skills/cisco-appdynamics-setup/SKILL.md
+++ b/skills/cisco-appdynamics-setup/SKILL.md
@@ -11,6 +11,17 @@ description: >-
 
 # Cisco AppDynamics Setup Automation
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Automates the **Cisco Splunk Add-on for AppDynamics**
 (`Splunk_TA_AppDynamics`).
 

--- a/skills/cisco-asa-ta-setup/SKILL.md
+++ b/skills/cisco-asa-ta-setup/SKILL.md
@@ -11,6 +11,17 @@ description: >-
 
 # Cisco ASA TA Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first workflow for `Splunk_TA_cisco-asa` and Cisco ASA/FTD syslog data.
 The skill emits reviewed placement notes, syslog handoffs, validation SPL, and
 readiness evidence templates. It does not open syslog listeners, install apps,

--- a/skills/cisco-catalyst-enhanced-netflow-setup/SKILL.md
+++ b/skills/cisco-catalyst-enhanced-netflow-setup/SKILL.md
@@ -9,6 +9,17 @@ description: >-
 
 # Cisco Catalyst Enhanced Netflow Add-on Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Automates installation and validation of the **Cisco Catalyst Enhanced Netflow
 Add-on for Splunk** (`splunk_app_stream_ipfix_cisco_hsl`).
 

--- a/skills/cisco-catalyst-ta-setup/SKILL.md
+++ b/skills/cisco-catalyst-ta-setup/SKILL.md
@@ -11,6 +11,17 @@ description: >-
 
 # Cisco Catalyst TA Setup Automation
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Automates the **Cisco Catalyst Add-on for Splunk** (`TA_cisco_catalyst`).
 
 ## Package Model

--- a/skills/cisco-dc-networking-setup/SKILL.md
+++ b/skills/cisco-dc-networking-setup/SKILL.md
@@ -10,6 +10,17 @@ description: >-
 
 # Cisco DC Networking TA Setup Automation
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Automates the **Cisco DC Networking App for Splunk** (`cisco_dc_networking_app_for_splunk`).
 
 ## Package Model

--- a/skills/cisco-enterprise-networking-setup/SKILL.md
+++ b/skills/cisco-enterprise-networking-setup/SKILL.md
@@ -10,6 +10,17 @@ description: >-
 
 # Cisco Enterprise Networking App Setup Automation
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Automates the **Cisco Enterprise Networking for Splunk Platform**
 (`cisco-catalyst-app`).
 

--- a/skills/cisco-intersight-setup/SKILL.md
+++ b/skills/cisco-intersight-setup/SKILL.md
@@ -11,6 +11,17 @@ description: >-
 
 # Cisco Intersight TA Setup Automation
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Automates the **Cisco Intersight Add-On for Splunk** (`Splunk_TA_Cisco_Intersight`).
 
 ## Package Model

--- a/skills/cisco-meraki-ta-setup/SKILL.md
+++ b/skills/cisco-meraki-ta-setup/SKILL.md
@@ -10,6 +10,17 @@ description: >-
 
 # Cisco Meraki TA Setup Automation
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Automates the **Splunk Add-on for Cisco Meraki** (`Splunk_TA_cisco_meraki`).
 
 ## Package Model

--- a/skills/cisco-secure-access-setup/SKILL.md
+++ b/skills/cisco-secure-access-setup/SKILL.md
@@ -11,6 +11,17 @@ description: >-
 
 # Cisco Secure Access Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Automates installation and core account configuration of the **Cisco Secure
 Access App for Splunk** (`cisco-cloud-security`) plus the required **Cisco
 Secure Access Add-on for Splunk** (`TA-cisco-cloud-security-addon`).

--- a/skills/cisco-secure-email-web-gateway-setup/SKILL.md
+++ b/skills/cisco-secure-email-web-gateway-setup/SKILL.md
@@ -10,6 +10,17 @@ description: >-
 
 # Cisco Secure Email/Web Gateway Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Automates Splunk-side setup for:
 
 - Cisco Email Security Appliance add-on (`Splunk_TA_cisco-esa`, Splunkbase

--- a/skills/cisco-security-cloud-setup/SKILL.md
+++ b/skills/cisco-security-cloud-setup/SKILL.md
@@ -9,6 +9,17 @@ description: >-
 
 # Cisco Security Cloud Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Automates installation and input configuration of **Cisco Security Cloud**
 (`CiscoSecurityCloud`).
 

--- a/skills/cisco-spaces-setup/SKILL.md
+++ b/skills/cisco-spaces-setup/SKILL.md
@@ -11,6 +11,17 @@ description: >-
 
 # Cisco Spaces TA Setup Automation
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Automates the **Cisco Spaces Add-on for Splunk** (`ta_cisco_spaces`).
 
 ## Package Model

--- a/skills/cisco-talos-intelligence-setup/SKILL.md
+++ b/skills/cisco-talos-intelligence-setup/SKILL.md
@@ -11,6 +11,17 @@ description: >-
 
 # Cisco Talos Intelligence Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Automates readiness checks for Cisco Talos Intelligence for Enterprise Security
 Cloud (`Splunk_TA_Talos_Intelligence`, Splunkbase `7557`).
 

--- a/skills/cisco-thousandeyes-setup/SKILL.md
+++ b/skills/cisco-thousandeyes-setup/SKILL.md
@@ -11,6 +11,17 @@ description: >-
 
 # Cisco ThousandEyes App Setup Automation
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Automates the **Cisco ThousandEyes App for Splunk** (`ta_cisco_thousandeyes`).
 
 ## How This App Differs From Other Cisco TAs

--- a/skills/cisco-ucs-ta-setup/SKILL.md
+++ b/skills/cisco-ucs-ta-setup/SKILL.md
@@ -10,6 +10,17 @@ description: >-
 
 # Cisco UCS TA Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Automates the Splunk Add-on for Cisco UCS (`Splunk_TA_cisco-ucs`, Splunkbase
 `2731`) using the package's REST handlers and configuration model.
 

--- a/skills/cisco-webex-setup/SKILL.md
+++ b/skills/cisco-webex-setup/SKILL.md
@@ -11,6 +11,17 @@ description: >-
 
 # Cisco Webex Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Automates the Webex Add-on for Splunk (`ta_cisco_webex_add_on_for_splunk`,
 Splunkbase `8365`) and the companion Webex App dashboards
 (`cisco_webex_meetings_app_for_splunk`, Splunkbase `4992`).

--- a/skills/shared/ta_completion_gate.md
+++ b/skills/shared/ta_completion_gate.md
@@ -1,0 +1,44 @@
+# Splunk TA Completion Gate
+
+Use this gate for every Splunk Technology Add-on, add-on bundle, or dashboard
+companion workflow before calling setup successful.
+
+## Data Ingest
+
+- Install the TA or add-on on the correct tier and create the target indexes.
+- Configure accounts through the add-on UI or REST handlers so secrets land in
+  Splunk encrypted storage, never in rendered files or command arguments.
+- Enable the data inputs, HEC tokens, file monitors, syslog receivers, DBX
+  inputs, or cloud subscriptions owned by the skill or its required companion.
+- Validate that events or metrics arrive in the expected index, source,
+  sourcetype, host, and time window, and review `_internal` logs for add-on
+  collection errors.
+- Run the relevant `splunk-data-source-readiness-doctor` source pack after data
+  lands when the skill has a readiness handoff.
+
+## Pre-Built Dashboards
+
+- Discover any package-shipped dashboards through `data/ui/views`, app metadata,
+  local package evidence, or the documented dashboard companion app.
+- Make dashboard apps visible in Splunk Web when the app is intended to expose
+  views, and keep TA-only apps hidden only when the package intentionally ships
+  no user-facing dashboards.
+- Apply dashboard defaults, index macros, saved-search enablement, lookup
+  building, data model acceleration, or dashboard app settings required by the
+  package.
+- Prove the dashboards are turned on successfully by validating that their
+  searches resolve against the configured indexes and return data after ingest
+  is confirmed.
+- If the TA ships no pre-built dashboards, record explicit evidence and name the
+  consuming app, ES/ITSI/ARI content, or readiness-doctor path that will use the
+  data instead.
+
+## Exit Criteria
+
+A TA setup is incomplete if the package is merely installed. The completion
+evidence must include enabled ingest and one of:
+
+- dashboard app visible plus dashboard searches returning data;
+- dashboard prerequisites configured and waiting only on a documented upstream
+  data source with owner/date; or
+- explicit package evidence that no pre-built dashboards ship with the TA.

--- a/skills/splunk-attack-analyzer-setup/SKILL.md
+++ b/skills/splunk-attack-analyzer-setup/SKILL.md
@@ -11,6 +11,17 @@ description: >-
 
 # Splunk Attack Analyzer Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Use this skill for the Splunk platform side of Splunk Attack Analyzer.
 
 ## Prerequisites

--- a/skills/splunk-aws-ta-setup/SKILL.md
+++ b/skills/splunk-aws-ta-setup/SKILL.md
@@ -14,6 +14,17 @@ description: >-
 
 # Splunk Add-on for AWS Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first automation for the **Splunk Add-on for AWS** (`Splunk_TA_aws`,
 Splunkbase `1876`). This is the **manual TA configuration path**: it renders
 the real modular-input stanzas, an account-setup runbook, and the index plan,

--- a/skills/splunk-box-ta-setup/SKILL.md
+++ b/skills/splunk-box-ta-setup/SKILL.md
@@ -11,6 +11,17 @@ description: >-
 
 # Splunk Add-on for Box Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first automation for `Splunk_TA_box` (Splunkbase `2679`, verified
 `4.0.0`). The renderer emits reviewable Box service inputs, an OAuth account
 runbook, install commands, metadata, and validation SPL. It never handles Box

--- a/skills/splunk-cyberark-ta-setup/SKILL.md
+++ b/skills/splunk-cyberark-ta-setup/SKILL.md
@@ -12,6 +12,17 @@ description: >-
 
 # CyberArk Splunk Add-on Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first umbrella workflow for CyberArk EPM and legacy EPV/PTA parsing.
 The skill keeps the support boundary explicit: `Splunk_TA_cyberark_epm`
 (Splunkbase `5160`, verified `4.0.0`) is the supported API path, while

--- a/skills/splunk-database-ta-setup/SKILL.md
+++ b/skills/splunk-database-ta-setup/SKILL.md
@@ -11,6 +11,17 @@ description: >-
 
 # Database Supported Add-ons Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first workflow for verified database add-ons:
 
 - `Splunk_TA_microsoft-sqlserver` `3.1.0`, Splunkbase `2648`

--- a/skills/splunk-gcp-ta-setup/SKILL.md
+++ b/skills/splunk-gcp-ta-setup/SKILL.md
@@ -15,6 +15,17 @@ description: >-
 
 # Splunk Add-on for Google Cloud Platform Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first automation for the **Splunk Add-on for Google Cloud Platform**
 (`Splunk_TA_google-cloudplatform`, Splunkbase `3088`). This skill centers on the
 **Cloud Logging -> Pub/Sub** ingestion path, which is the GCP SIEM/audit feed,

--- a/skills/splunk-github-ta-setup/SKILL.md
+++ b/skills/splunk-github-ta-setup/SKILL.md
@@ -13,6 +13,17 @@ description: >-
 
 # Splunk Add-on for GitHub Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first automation for `Splunk_TA_github` (Splunkbase `6254`, verified
 `3.3.0`). The renderer emits reviewable GitHub Cloud API inputs, a PAT account
 runbook, HEC/syslog handoffs, and validation SPL. It never handles PAT or HEC

--- a/skills/splunk-google-workspace-ta-setup/SKILL.md
+++ b/skills/splunk-google-workspace-ta-setup/SKILL.md
@@ -14,6 +14,17 @@ description: >-
 
 # Splunk Add-on for Google Workspace Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first automation for `Splunk_TA_Google_Workspace` (Splunkbase `5556`,
 verified `4.0.0`). The renderer emits reviewable `inputs.conf` and settings
 overlays for the six package input families and a service-account/certificate

--- a/skills/splunk-microsoft-cloud-setup/SKILL.md
+++ b/skills/splunk-microsoft-cloud-setup/SKILL.md
@@ -16,6 +16,17 @@ description: >-
 
 # Microsoft Cloud Add-ons Setup (Office 365, Entra ID, Graph)
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first automation for Microsoft cloud log onboarding through two real
 Splunk-supported add-ons:
 

--- a/skills/splunk-microsoft-exchange-ta-setup/SKILL.md
+++ b/skills/splunk-microsoft-exchange-ta-setup/SKILL.md
@@ -12,6 +12,17 @@ description: >-
 
 # Microsoft Exchange Supported Add-on Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first workflow for the verified Microsoft Exchange packages:
 
 - Exchange bundle `4.1.0`, Splunkbase `3225`

--- a/skills/splunk-microsoft-scom-ta-setup/SKILL.md
+++ b/skills/splunk-microsoft-scom-ta-setup/SKILL.md
@@ -11,6 +11,17 @@ description: >-
 
 # Microsoft SCOM Supported Add-on Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first workflow for `Splunk_TA_microsoft-scom` `4.5.0`, Splunkbase
 `2729`.
 

--- a/skills/splunk-microsoft-security-ta-setup/SKILL.md
+++ b/skills/splunk-microsoft-security-ta-setup/SKILL.md
@@ -14,6 +14,17 @@ description: >-
 
 # Splunk Add-on for Microsoft Security Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first automation for `Splunk_TA_MS_Security` (Splunkbase `6207`,
 verified `3.0.0`). The renderer emits reviewable inputs, macro overlays for
 package-shipped searches, an Entra app/client-secret account runbook, and

--- a/skills/splunk-netapp-ontap-ta-setup/SKILL.md
+++ b/skills/splunk-netapp-ontap-ta-setup/SKILL.md
@@ -11,6 +11,17 @@ description: >-
 
 # NetApp ONTAP Supported Add-ons Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first workflow for verified ONTAP packages:
 
 - `Splunk_TA_ontap` `3.2.0`, Splunkbase `3418`

--- a/skills/splunk-observability-cloud-integration-setup/SKILL.md
+++ b/skills/splunk-observability-cloud-integration-setup/SKILL.md
@@ -16,6 +16,17 @@ description: >-
 
 # Splunk Platform <-> Splunk Observability Cloud Integration Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Single skill that pairs a Splunk Cloud Platform or Splunk Enterprise stack with
 Splunk Observability Cloud and configures every navigate-into-O11y surface:
 Unified Identity SSO, Centralized RBAC, the in-app Discover app, Related

--- a/skills/splunk-observability-otel-collector-setup/SKILL.md
+++ b/skills/splunk-observability-otel-collector-setup/SKILL.md
@@ -5,6 +5,17 @@ description: Use when telemetry pipeline management needs Splunk OTel Collector 
 
 # Splunk Observability OTel Collector Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 ## Overview
 
 Use this skill to render, review, and optionally apply Splunk Distribution of OpenTelemetry Collector deployments for Kubernetes, Linux hosts, and Splunkbase app `7125` (Splunk Add-On for OpenTelemetry Collector) on Universal Forwarders.

--- a/skills/splunk-okta-ta-setup/SKILL.md
+++ b/skills/splunk-okta-ta-setup/SKILL.md
@@ -14,6 +14,17 @@ description: >-
 
 # Splunk Add-on for Okta Identity Cloud Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first automation for the **Splunk Add-on for Okta Identity Cloud**
 (`Splunk_TA_okta_identity_cloud`, Splunkbase `6553`). The add-on ingests Okta
 System Log events and Universal Directory state (users, groups, apps) through

--- a/skills/splunk-rsa-securid-ta-setup/SKILL.md
+++ b/skills/splunk-rsa-securid-ta-setup/SKILL.md
@@ -12,6 +12,17 @@ description: >-
 
 # RSA SecurID Splunk Add-on Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first umbrella workflow for RSA SecurID Authentication Manager and RSA
 SecurID Cloud Authentication Service. CAS is API-driven; AM is syslog/parser
 based.

--- a/skills/splunk-salesforce-ta-setup/SKILL.md
+++ b/skills/splunk-salesforce-ta-setup/SKILL.md
@@ -11,6 +11,17 @@ description: >-
 
 # Splunk Add-on for Salesforce Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first automation for `Splunk_TA_salesforce` (Splunkbase `3549`, verified
 `6.0.2`). The renderer emits reviewable object/event-log inputs, an OAuth or
 connected-app account runbook, install commands, metadata, and validation SPL.

--- a/skills/splunk-security-appliance-ta-setup/SKILL.md
+++ b/skills/splunk-security-appliance-ta-setup/SKILL.md
@@ -12,6 +12,17 @@ description: >-
 
 # Security Appliance Supported Add-ons Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first workflow for the verified security appliance packages:
 
 - `Splunk_TA_bit9-carbonblack` `3.0.0`, Splunkbase `2790`

--- a/skills/splunk-servicenow-ta-setup/SKILL.md
+++ b/skills/splunk-servicenow-ta-setup/SKILL.md
@@ -13,6 +13,17 @@ description: >-
 
 # Splunk Add-on for ServiceNow Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first automation for the **Splunk Add-on for ServiceNow**
 (`Splunk_TA_snow`, Splunkbase `1928`). The add-on pulls ServiceNow table records
 through the REST API; each `snow://<table>` input emits the `snow:<table>`

--- a/skills/splunk-stream-setup/SKILL.md
+++ b/skills/splunk-stream-setup/SKILL.md
@@ -11,6 +11,17 @@ description: >-
 
 # Splunk Stream Setup Automation
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Automates installation and configuration of the **Splunk Stream** stack:
 
 | App | Package ID | Purpose |

--- a/skills/splunk-supported-addons-setup/SKILL.md
+++ b/skills/splunk-supported-addons-setup/SKILL.md
@@ -12,6 +12,17 @@ description: >-
 
 # Splunk Supported Add-ons Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Use this skill as the router for Splunk-supported add-ons before choosing an
 install or configuration workflow. First-class profiles cover Unix/Linux:
 

--- a/skills/splunk-syslog-web-proxy-ta-setup/SKILL.md
+++ b/skills/splunk-syslog-web-proxy-ta-setup/SKILL.md
@@ -12,6 +12,17 @@ description: >-
 
 # Syslog, Web, And Proxy Supported Add-on Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Shared render-first workflow for parser and web/proxy add-ons where the primary
 work is transport ownership and exact package source-type stamping. Web-server
 profiles default to local file/Universal Forwarder monitors, IIS defaults to a

--- a/skills/splunk-sysmon-ta-setup/SKILL.md
+++ b/skills/splunk-sysmon-ta-setup/SKILL.md
@@ -13,6 +13,17 @@ description: >-
 
 # Splunk Add-on for Microsoft Sysmon Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first automation for `Splunk_TA_microsoft_sysmon` (Splunkbase `5709`,
 verified `5.0.0`). The renderer emits one collection mode at a time:
 endpoint direct collection or Windows Event Collector. It does not install

--- a/skills/splunk-vmware-ta-setup/SKILL.md
+++ b/skills/splunk-vmware-ta-setup/SKILL.md
@@ -12,6 +12,17 @@ description: >-
 
 # Splunk VMware TA Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first workflow for VMware data onboarding through Splunk Supported
 Add-ons. VMware coverage spans multiple glossary entries: VMware, vCenter Logs,
 ESXi Logs, VMware Extractions, VMware Indexes, VMware Metrics, and VMware

--- a/skills/splunk-windows-ta-setup/SKILL.md
+++ b/skills/splunk-windows-ta-setup/SKILL.md
@@ -14,6 +14,17 @@ description: >-
 
 # Splunk Add-on for Microsoft Windows Setup
 
+## TA Completion Gate
+
+For every TA/add-on or dashboard companion run, satisfy the shared
+[TA completion gate](../shared/ta_completion_gate.md): configure and enable the
+data ingest path owned by this skill or its required companion, validate events
+or metrics in the target indexes/source types, and verify any
+pre-built/package-shipped dashboards are visible, macro-aligned, and returning
+data. If the package ships no dashboards, record that evidence explicitly and
+hand off dashboard use to the consuming app, ES/ITSI/ARI content, or readiness
+doctor.
+
 Render-first automation for the **Splunk Add-on for Microsoft Windows**
 (`Splunk_TA_windows`, Splunkbase `742`). The add-on collects Windows Event Log,
 performance counters, and host-monitoring data. Inputs run on Windows

--- a/tests/test_ta_completion_gate.py
+++ b/tests/test_ta_completion_gate.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Coverage for Splunk TA ingest and dashboard completion requirements."""
+
+from __future__ import annotations
+
+from tests.regression_helpers import REPO_ROOT
+
+
+SKILLS = REPO_ROOT / "skills"
+
+TA_COMPANION_SKILLS = {
+    "cisco-appdynamics-setup",
+    "cisco-catalyst-enhanced-netflow-setup",
+    "cisco-dc-networking-setup",
+    "cisco-enterprise-networking-setup",
+    "cisco-intersight-setup",
+    "cisco-secure-access-setup",
+    "cisco-secure-email-web-gateway-setup",
+    "cisco-security-cloud-setup",
+    "cisco-spaces-setup",
+    "cisco-talos-intelligence-setup",
+    "cisco-thousandeyes-setup",
+    "cisco-webex-setup",
+    "splunk-attack-analyzer-setup",
+    "splunk-microsoft-cloud-setup",
+    "splunk-stream-setup",
+    "splunk-supported-addons-setup",
+}
+
+SKILL_REQUIRED_PHRASES = (
+    "## TA Completion Gate",
+    "../shared/ta_completion_gate.md",
+    "data ingest path",
+    "pre-built/package-shipped dashboards",
+    "macro-aligned",
+    "returning data",
+    "package ships no dashboards",
+)
+
+
+def ta_skill_names() -> list[str]:
+    suffix_skills = {path.name for path in SKILLS.glob("*-ta-setup") if path.is_dir()}
+    return sorted(suffix_skills | TA_COMPANION_SKILLS)
+
+
+def test_shared_ta_completion_gate_defines_ingest_and_dashboard_evidence() -> None:
+    text = (SKILLS / "shared/ta_completion_gate.md").read_text(encoding="utf-8")
+    for phrase in (
+        "## Data Ingest",
+        "## Pre-Built Dashboards",
+        "data/ui/views",
+        "visible",
+        "index macros",
+        "return data after ingest",
+        "no pre-built dashboards",
+    ):
+        assert phrase in text
+
+
+def test_ta_skills_reference_completion_gate() -> None:
+    failures: list[str] = []
+    for skill_name in ta_skill_names():
+        skill_file = SKILLS / skill_name / "SKILL.md"
+        text = skill_file.read_text(encoding="utf-8")
+        normalized = " ".join(text.split())
+        missing = [
+            phrase
+            for phrase in SKILL_REQUIRED_PHRASES
+            if " ".join(phrase.split()) not in normalized
+        ]
+        if missing:
+            failures.append(f"{skill_name}: missing {', '.join(missing)}")
+
+    assert not failures, "\n".join(failures)
+
+
+def test_requirements_catalog_mentions_ta_completion_gate() -> None:
+    text = (REPO_ROOT / "SKILL_REQUIREMENTS.md").read_text(encoding="utf-8")
+    for phrase in (
+        "skills/shared/ta_completion_gate.md",
+        "data ingest must be configured",
+        "pre-built dashboards",
+        "returning data",
+    ):
+        assert phrase in text
+
+
+def test_agent_contexts_mention_ta_completion_gate() -> None:
+    for name in ("AGENTS.md", "CLAUDE.md"):
+        text = (REPO_ROOT / name).read_text(encoding="utf-8")
+        for phrase in (
+            "skills/shared/ta_completion_gate.md",
+            "package install alone",
+            "dashboard companion",
+            "validate data ingest",
+            "ships no pre-built dashboards",
+        ):
+            assert phrase in text

--- a/tests/test_ta_completion_gate.py
+++ b/tests/test_ta_completion_gate.py
@@ -23,9 +23,43 @@ TA_COMPANION_SKILLS = {
     "cisco-webex-setup",
     "splunk-attack-analyzer-setup",
     "splunk-microsoft-cloud-setup",
+    "splunk-observability-cloud-integration-setup",
+    "splunk-observability-otel-collector-setup",
     "splunk-stream-setup",
     "splunk-supported-addons-setup",
 }
+
+TA_MENTION_EXCLUDED_SKILLS = {
+    "cisco-isovalent-platform-setup",
+    "cisco-thousandeyes-mcp-setup",
+    "splunk-ai-ml-toolkit-setup",
+    "splunk-app-install",
+    "splunk-appdynamics-setup",
+    "splunk-asset-risk-intelligence-setup",
+    "splunk-cim-data-model-setup",
+    "splunk-connect-for-otlp-setup",
+    "splunk-db-connect-setup",
+    "splunk-enterprise-security-config",
+    "splunk-enterprise-security-install",
+    "splunk-federated-search-setup",
+    "splunk-license-manager-setup",
+    "splunk-observability-aws-integration",
+    "splunk-observability-azure-integration",
+    "splunk-observability-cisco-intersight-integration",
+    "splunk-observability-deep-native-workflows",
+    "splunk-observability-gcp-integration",
+    "splunk-observability-native-ops",
+    "splunk-observability-thousandeyes-integration",
+    "splunk-oncall-setup",
+}
+
+TA_OWNER_MARKERS = (
+    "Splunk Add-on",
+    "Splunk Add-On",
+    "Splunk_TA_",
+    "Technology Add-on",
+    "Splunk-side companion",
+)
 
 SKILL_REQUIRED_PHRASES = (
     "## TA Completion Gate",
@@ -41,6 +75,24 @@ SKILL_REQUIRED_PHRASES = (
 def ta_skill_names() -> list[str]:
     suffix_skills = {path.name for path in SKILLS.glob("*-ta-setup") if path.is_dir()}
     return sorted(suffix_skills | TA_COMPANION_SKILLS)
+
+
+def test_non_suffix_addon_mentions_are_classified() -> None:
+    suffix_skills = {path.name for path in SKILLS.glob("*-ta-setup") if path.is_dir()}
+    suspected = {
+        path.parent.name
+        for path in SKILLS.glob("*/SKILL.md")
+        if path.parent.name not in suffix_skills
+        and any(marker in path.read_text(encoding="utf-8") for marker in TA_OWNER_MARKERS)
+    }
+
+    unclassified = suspected - TA_COMPANION_SKILLS - TA_MENTION_EXCLUDED_SKILLS
+
+    assert not unclassified, (
+        "Classify non-suffix add-on mentions as TA_COMPANION_SKILLS when the "
+        "skill owns ingest/setup, or TA_MENTION_EXCLUDED_SKILLS when it is a "
+        f"handoff/governance-only mention: {sorted(unclassified)}"
+    )
 
 
 def test_shared_ta_completion_gate_defines_ingest_and_dashboard_evidence() -> None:


### PR DESCRIPTION
## Summary

- Add a shared TA completion gate that requires data ingest validation plus pre-built dashboard readiness or explicit no-dashboard evidence.
- Reference the gate from the top-level agent contexts, skill requirements, and 40 TA/add-on/dashboard companion skills.
- Add regression coverage to prevent future TA skills from missing the ingest and dashboard completion criteria.

## Validation

- `pytest tests/test_ta_completion_gate.py`
- `pytest tests/test_project_skill_actionability.py tests/test_splunk_cloud_endpoint_ta_setups.py tests/test_package_verified_supported_addons_expansion.py tests/test_cisco_ta_regressions.py`
- `python3 tests/check_skill_frontmatter.py`
- `pytest tests/test_registry_regressions.py tests/test_skill_coverage_handoffs.py`
- `python3 tests/check_repo_readiness.py`
- `git diff --check`