### PR TITLE
[codex] Add Galileo logging handoff and configurable Codex collector endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ projects/tmp-*
 /cisco-cloud-control-rendered/
 /cisco-thousandeyes-mcp-rendered/
 /galileo-agent-control-rendered/
+/galileo-mcp-rendered/
 /galileo-platform-rendered/
 /sc4s-rendered/
 /sc4snmp-rendered/

--- a/skills/galileo-platform-setup/SKILL.md
+++ b/skills/galileo-platform-setup/SKILL.md
@@ -49,6 +49,11 @@ logic.
    `/v2/projects/{project_id}/export_records` using JSONL by default.
 4. **Observe runtime**: render Python and Kubernetes Galileo
    OpenTelemetry/OpenInference snippets.
+   For Codex itself, use the rendered `runtime/codex-notify-galileo-handoff.md`
+   guidance: Galileo MCP connectivity does not automatically populate Observe
+   log streams, so interactive Codex turn logging requires a separate
+   `notify`-based bridge that writes `codex.turn` traces through Galileo direct
+   trace ingest.
 5. **Protect runtime**: render a file-secret-backed legacy Python helper for
    `/v2/protect/invoke` where an existing deployment still uses Protect.
 6. **Evaluate assets**: render handoffs for experiments, datasets, metrics
@@ -158,6 +163,21 @@ Use `--lifecycle-manifest`, `--dataset-dir`, `--prompt-manifest`,
 `--experiment-manifest`, `--protect-stage-manifest`, and `--metrics` when the
 tenant needs Galileo objects provisioned before export or runtime handoff.
 
+## Codex Turn Logging Note
+
+When instrumenting Codex as a coding agent, expect three separate surfaces:
+
+- Galileo MCP server: tool access only.
+- Codex native `[otel]` profile: Codex-managed OTel export.
+- Codex `notify` bridge: post-turn session JSONL parsing and direct Galileo
+  trace ingest.
+
+Use the `notify` bridge when the requirement is "every completed Codex turn
+appears in a Galileo log stream." The bridge should read the Galileo API key
+from `--galileo-api-key-file`, send `POST /v2/projects/{project_id}/traces`
+with `reliable=true` and `include_trace_ids=true`, and verify storage through
+`traces/count` plus `export_records`.
+
 ## Secret Handling
 
 Use file-based flags only:
@@ -172,6 +192,10 @@ flags such as `--galileo-api-key`, `--splunk-hec-token`, `--o11y-token`,
 
 Rendered output must not contain token values. Apply wrappers read token files
 at runtime and keep secret material out of argv.
+
+For Codex notify turn logging, the same rule applies: the notifier reads
+`GALILEO_API_KEY_FILE` at runtime, logs only non-secret local failure evidence,
+and exits `0` if Galileo is temporarily unavailable.
 
 ## Validation
 

--- a/skills/galileo-platform-setup/reference.md
+++ b/skills/galileo-platform-setup/reference.md
@@ -220,6 +220,71 @@ Raw prompt/response fields are excluded unless the operator explicitly passes
 `--include-raw` to the bridge script and confirms Splunk is an approved
 destination.
 
+## Codex Notify Runtime Logging
+
+Use this pattern when the agent being instrumented is Codex itself and the
+operator expects completed interactive turns to appear in a Galileo Observe log
+stream.
+
+Galileo MCP and Galileo logging are separate:
+
+- Galileo MCP lets Codex call Galileo tools.
+- It does not automatically mirror Codex turns into Galileo Observe.
+- A Codex `notify` bridge is needed for post-turn logging.
+
+The bridge should run after `turn-ended`, parse the completed turn from the
+local Codex session JSONL, and write one trace to Galileo direct ingest:
+
+```text
+POST /v2/projects/{project_id}/traces
+```
+
+Recommended payload fields:
+
+- `log_stream_id`: target coding-agent log stream
+- `logging_method`: `api_direct`
+- `reliable`: `true`
+- `include_trace_ids`: `true`
+- `session_external_id`: Codex session ID
+- trace `name`: `codex.turn`
+- trace `tags`: `codex`, `codex-cli`, `turn-ended`
+- child spans: one `llm` span for the turn and `tool` / `retriever` spans for
+  tool calls or web-search events when present
+
+Use `redacted_input` and `redacted_output` when sending captured content.
+Prompt, response, tool argument, and tool output capture requires explicit
+operator acceptance; otherwise prefer metadata-only placeholders.
+
+`user_metadata` values must be strings. Convert counts, booleans, numeric IDs,
+and similar values before sending. Non-string metadata values can produce HTTP
+`422` validation errors.
+
+Keep the notifier fail-soft:
+
+- read the Galileo key from `GALILEO_API_KEY_FILE`
+- never pass API keys on argv
+- redact obvious secrets, bearer tokens, JWTs, and high-entropy strings
+- maintain a local duplicate-suppression state file such as
+  `CODEX_HOME/log/codex-galileo-emitted-turns.json`
+- write local non-secret failure evidence to
+  `CODEX_HOME/log/codex-galileo-notify.log`
+- exit `0` if Galileo is unavailable so telemetry cannot block Codex
+
+Verify that a turn is stored, not merely accepted, by filtering on the returned
+trace ID:
+
+```text
+POST /v2/projects/{project_id}/traces/count
+POST /v2/projects/{project_id}/export_records
+```
+
+Expected proof:
+
+- ingest returns `records_count`, `traces_count`, `spans_count`, and
+  `trace_ids`
+- count returns `total_count >= 1`
+- export returns one JSONL trace whose `id` matches the returned trace ID
+
 ## Multimodal Observability
 
 Rendered assets:

--- a/skills/galileo-platform-setup/scripts/render_assets.py
+++ b/skills/galileo-platform-setup/scripts/render_assets.py
@@ -794,6 +794,87 @@ export GALILEO_CONSOLE_URL={shell_quote(config["galileo_console_url"])}
 """,
     )
     write_text(
+        output_dir / "runtime/codex-notify-galileo-handoff.md",
+        f"""# Codex Notify to Galileo Runtime Handoff
+
+Use this handoff when Codex itself should write completed interactive turns into
+this Galileo project and log stream.
+
+## What This Solves
+
+Configuring the Galileo MCP server lets Codex call Galileo MCP tools. It does
+not automatically send Codex conversations, tool calls, or turn results into a
+Galileo log stream.
+
+For interactive Codex, the proven runtime path is a fail-soft `notify` bridge:
+
+1. Codex finishes a turn and invokes its configured `notify` command.
+2. The notifier parses the newest completed turn from
+   `CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl`, or the session JSONL path
+   in the notify payload when available.
+3. The notifier writes one Galileo trace named `codex.turn` with child spans
+   for the LLM turn, tool calls, and web retrievals.
+4. The notifier exits `0` even if Galileo is unavailable, and records local
+   non-secret evidence in `CODEX_HOME/log/codex-galileo-notify.log`.
+
+## Target Galileo Objects
+
+- API base: `{config["galileo_api_base"]}`
+- Project: `{config["project_name"]}` (`{config["project_id"]}`)
+- Log stream: `{config["log_stream"]}` (`{config["log_stream_id"]}`)
+
+## Direct Ingest Contract
+
+Send completed turns to:
+
+```text
+POST /v2/projects/{{project_id}}/traces
+```
+
+Recommended request settings:
+
+- `log_stream_id`: target Codex log stream ID
+- `logging_method`: `api_direct`
+- `reliable`: `true`
+- `include_trace_ids`: `true`
+- `session_external_id`: Codex session ID
+- trace name: `codex.turn`
+- trace tags: `codex`, `codex-cli`, `turn-ended`
+
+Use `redacted_input` and `redacted_output` when sending any content. Keep
+metadata-only placeholders unless the operator explicitly accepts prompt,
+response, tool argument, and tool output capture.
+
+Galileo `user_metadata` values must be strings. Convert values such as
+`tool_count`, `retrieval_count`, booleans, or numeric IDs before sending.
+
+## Verification Contract
+
+API acceptance is not enough. Verify storage by filtering on the returned trace
+ID with:
+
+```text
+POST /v2/projects/{{project_id}}/traces/count
+POST /v2/projects/{{project_id}}/export_records
+```
+
+Expected evidence:
+
+- ingest response has `records_count`, `traces_count`, `spans_count`, and
+  `trace_ids`
+- count response has `total_count >= 1`
+- export response returns a JSONL record whose `id` equals the returned trace ID
+
+## Guardrails
+
+- Read the Galileo key from `GALILEO_API_KEY_FILE`; never pass it on argv.
+- Redact obvious secrets, bearer tokens, JWTs, and high-entropy strings.
+- Keep duplicate suppression state locally, for example
+  `CODEX_HOME/log/codex-galileo-emitted-turns.json`.
+- Keep the bridge fail-soft. Telemetry must not block Codex.
+""",
+    )
+    write_text(
         output_dir / "runtime/python-opentelemetry-galileo.py",
         f'''"""Minimal Galileo OpenTelemetry/OpenInference setup.
 
@@ -1301,6 +1382,14 @@ def product_coverage_matrix(config: dict[str, Any]) -> list[dict[str, Any]]:
             "rendered_assets": ["runtime/", "splunk-platform/export-records-request.json"],
             "apply_script": "scripts/apply-observe-export.sh",
             "docs": "https://docs.galileo.ai/sdk-api/logging/logging-basics",
+        },
+        {
+            "surface": "Codex notify turn logging",
+            "lifecycle": ["codex_notify_handoff", "direct_trace_ingest", "count_and_export_validation"],
+            "coverage": "rendered_handoff_for_fail_soft_codex_turn_logging_into_galileo_observe",
+            "rendered_assets": ["runtime/codex-notify-galileo-handoff.md"],
+            "apply_script": "scripts/apply-observe-runtime.sh",
+            "docs": "https://docs.galileo.ai/api-reference/trace/log-traces",
         },
         {
             "surface": "Tags, metadata, run labels, and filter hygiene",

--- a/skills/galileo-platform-setup/template.example
+++ b/skills/galileo-platform-setup/template.example
@@ -68,6 +68,15 @@ runtime:
   deployment_environment: "production"
   target_dir: ""
 
+coding_agent:
+  # Galileo MCP does not automatically populate log streams. Use a Codex
+  # notify bridge for completed interactive turn logging.
+  codex_notify_handoff: true
+  codex_trace_name: "codex.turn"
+  codex_tags: "codex,codex-cli,turn-ended"
+  codex_duplicate_state_file: "~/.codex/log/codex-galileo-emitted-turns.json"
+  codex_notify_log_file: "~/.codex/log/codex-galileo-notify.log"
+
 otlp:
   receiver_host: "otlp.example.com"
   grpc_port: "4317"

--- a/skills/shared/coding_agent_o11y/codex.py
+++ b/skills/shared/coding_agent_o11y/codex.py
@@ -99,8 +99,10 @@ def parse_local_collector_endpoint(value: object) -> SplitResult:
     if not raw:
         raise UsageError("local_collector_endpoint is required")
     parsed = urlsplit(raw)
-    if parsed.scheme not in {"http", "https"}:
-        raise UsageError("local_collector_endpoint must use http:// or https://")
+    if parsed.scheme != "http":
+        raise UsageError(
+            "local_collector_endpoint must use http:// because the rendered local collector receiver is plain OTLP HTTP"
+        )
     if not parsed.hostname:
         raise UsageError("local_collector_endpoint must include a host")
     if parsed.username or parsed.password:

--- a/skills/shared/coding_agent_o11y/codex.py
+++ b/skills/shared/coding_agent_o11y/codex.py
@@ -13,6 +13,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import SplitResult, urlsplit
 
 from skills.shared.coding_agent_o11y.common import (
     REPO_ROOT,
@@ -93,6 +94,41 @@ def destinations_for(value: str) -> list[str]:
     return ["local-collector", "external-collector", "direct"] if value == "all" else [value]
 
 
+def parse_local_collector_endpoint(value: object) -> SplitResult:
+    raw = str(value or "").strip()
+    if not raw:
+        raise UsageError("local_collector_endpoint is required")
+    parsed = urlsplit(raw)
+    if parsed.scheme not in {"http", "https"}:
+        raise UsageError("local_collector_endpoint must use http:// or https://")
+    if not parsed.hostname:
+        raise UsageError("local_collector_endpoint must include a host")
+    if parsed.username or parsed.password:
+        raise UsageError("local_collector_endpoint must not include credentials")
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise UsageError(f"local_collector_endpoint has an invalid port: {exc}") from exc
+    if port is None:
+        raise UsageError("local_collector_endpoint must include an explicit port")
+    if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+        raise UsageError("local_collector_endpoint must be a base URL such as http://localhost:14318")
+    return parsed
+
+
+def normalize_local_collector_endpoint(value: object) -> str:
+    parsed = parse_local_collector_endpoint(value)
+    return f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
+
+
+def local_collector_receiver_endpoint(value: object) -> str:
+    parsed = parse_local_collector_endpoint(value)
+    host = parsed.hostname or ""
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    return f"{host}:{parsed.port}"
+
+
 def resolve_codex_home(config: dict[str, Any]) -> Path:
     configured = str(config.get("codex", {}).get("codex_home") or "").strip()
     if configured:
@@ -116,6 +152,7 @@ def load_spec_with_args(args: argparse.Namespace) -> dict[str, Any]:
         "service_name": args.service_name,
         "realm": args.realm,
         "destination": args.destination,
+        "local_collector_endpoint": args.local_collector_endpoint,
         "external_collector_protocol": args.external_collector_protocol,
         "external_trace_endpoint": args.external_trace_endpoint,
         "external_metric_endpoint": args.external_metric_endpoint,
@@ -170,6 +207,11 @@ def validate_config(config: dict[str, Any]) -> tuple[list[str], list[str]]:
     protocol = str(codex.get("external_collector_protocol", "otlp-http"))
     if protocol not in VALID_PROTOCOLS:
         errors.append("external_collector_protocol must be otlp-http or otlp-grpc")
+
+    try:
+        normalize_local_collector_endpoint(codex.get("local_collector_endpoint"))
+    except UsageError as exc:
+        errors.append(str(exc))
 
     if codex.get("content_capture") and not codex.get("accept_content_capture"):
         errors.append("prompt/response/tool-output capture requires --accept-content-capture")
@@ -237,7 +279,7 @@ def exporter_inline(protocol: str, endpoint: str, *, headers: dict[str, str] | N
 
 def local_profile(config: dict[str, Any]) -> str:
     codex = config["codex"]
-    endpoint = str(codex["local_collector_endpoint"]).rstrip("/")
+    endpoint = normalize_local_collector_endpoint(codex["local_collector_endpoint"])
     native = bool(codex.get("enable_native_logs"))
     exporter = exporter_inline("otlp-http", endpoint + "/v1/logs") if native else toml_quote("none")
     lines = [
@@ -310,6 +352,7 @@ def render_collector_overlay(config: dict[str, Any]) -> str:
     codex = config["codex"]
     realm = str(codex.get("realm") or "us0")
     native_logs = bool(codex.get("enable_native_logs"))
+    receiver_endpoint = local_collector_receiver_endpoint(codex["local_collector_endpoint"])
     logs_pipeline = (
         """    logs/codex:
       receivers: [otlp/codex]
@@ -325,7 +368,7 @@ receivers:
   otlp/codex:
     protocols:
       http:
-        endpoint: 127.0.0.1:14318
+        endpoint: {yaml_quote(receiver_endpoint)}
 
 processors:
   batch/codex: {{}}
@@ -839,6 +882,90 @@ export CODEX_O11Y_CAPTURE_CONTENT={shell_quote(capture)}
 """
 
 
+def render_galileo_notify_handoff(config: dict[str, Any]) -> str:
+    codex = config["codex"]
+    return f"""# Codex Notify to Galileo Handoff
+
+This handoff captures the proven path for sending completed Codex turns into a
+Galileo Observe log stream. It is separate from Codex native `[otel]` profile
+export and from the Galileo MCP server.
+
+## Key Behavior
+
+- A configured Galileo MCP server gives Codex access to Galileo tools, but it
+  does not automatically subscribe to or mirror Codex turns.
+- Codex native `[otel]` profile export is controlled by the active Codex
+  profile. If `[otel].exporter = "none"`, native Codex log export is disabled;
+  a `notify` command can still run at turn end.
+- The practical interactive path is a fail-soft `notify` wrapper that runs on
+  `turn-ended`, parses the local session JSONL under `CODEX_HOME/sessions`, and
+  logs one Galileo trace per completed turn.
+- Use Galileo direct trace ingest for this bridge:
+  `POST /v2/projects/{{project_id}}/traces`.
+- Set `reliable=true` and `include_trace_ids=true` so the notifier can log
+  non-secret acknowledgement evidence.
+- Verify storage, not only ingest acceptance, with:
+  `POST /v2/projects/{{project_id}}/traces/count` and
+  `POST /v2/projects/{{project_id}}/export_records`.
+- Galileo `user_metadata` values must be strings. Convert counts and booleans
+  before sending them.
+
+## Recommended Trace Shape
+
+- Trace name: `codex.turn`
+- Tags: `codex`, `codex-cli`, `turn-ended`
+- User metadata: `turn_id`, `session_id`, `event`, `model`,
+  `collaboration_mode`, `host`, `session_file`, `tool_count`,
+  `retrieval_count`
+- One LLM child span for the turn summary
+- Tool child spans for terminal, patch, MCP, browser, or other tool calls
+- Retriever child spans for web-search events when present
+
+## Secret And Content Guardrails
+
+- Read the Galileo API key from a file such as `GALILEO_API_KEY_FILE`; never
+  pass the key on argv.
+- Keep the notifier fail-soft: local failures should write a log and exit `0`
+  so telemetry cannot block Codex.
+- Keep a local emitted-turn state file to avoid duplicate turn export. A common
+  path is `CODEX_HOME/log/codex-galileo-emitted-turns.json`.
+- Log non-secret local failures to a separate file, for example
+  `CODEX_HOME/log/codex-galileo-notify.log`.
+- Redact obvious secrets, bearer tokens, JWTs, and high-entropy strings before
+  sending content to Galileo.
+- Prompt, response, tool argument, and tool output capture is data capture. Use
+  metadata-only placeholders unless the operator explicitly accepts content
+  capture.
+
+## Local Verification Pattern
+
+After a turn completes, the notifier should print or log non-secret evidence
+similar to:
+
+```json
+{{
+  "ok": true,
+  "turn_id": "019f...",
+  "trace_id": "uuid",
+  "galileo_trace_ids": ["uuid"],
+  "records_count": 22,
+  "spans_count": 21
+}}
+```
+
+Then verify by filtering on the returned trace ID through `traces/count` and
+`export_records`. A stored turn should export as a `codex.turn` trace with
+`event=turn-ended`.
+
+## Splunk O11y Relationship
+
+This skill still renders Splunk Observability profiles, collector overlays, and
+JSONL helpers for `{codex.get("service_name", "codex-cli")}`. The Galileo
+notify bridge is a companion handoff for Galileo Observe; it does not replace
+the Splunk OTel profile or collector path.
+"""
+
+
 def render_handoff(config: dict[str, Any], output_dir: Path) -> str:
     codex = config["codex"]
     lines = [
@@ -860,6 +987,10 @@ def render_handoff(config: dict[str, Any], output_dir: Path) -> str:
         "",
         f"Use `{output_dir / 'bin' / 'codex-o11y-exec'}` for `codex exec --json` metadata capture.",
         f"Content capture is `{str(bool(codex.get('content_capture'))).lower()}`.",
+        "",
+        "## Galileo Notify Bridge",
+        "",
+        "Review `runtime/codex-notify-galileo-handoff.md` when Codex turns must appear in a Galileo Observe log stream. Galileo MCP connectivity alone does not emit Codex turns.",
     ]
     return "\n".join(lines) + "\n"
 
@@ -907,6 +1038,7 @@ def render(config: dict[str, Any], output_dir: Path, json_output: bool = False) 
         hooks_json(resolve_codex_home(config) / "hooks" / "codex-o11y-stop-hook.py"),
     )
     write_text(output_dir / "runtime" / "codex-o11y.env", render_runtime_env(config, output_dir))
+    write_text(output_dir / "runtime" / "codex-notify-galileo-handoff.md", render_galileo_notify_handoff(config))
 
     plan = apply_plan(config, output_dir)
     coverage = coverage_report(config)
@@ -952,6 +1084,7 @@ def validate_output(output_dir: Path, json_output: bool = False) -> dict[str, An
         "handoff.md",
         "collector/codex-o11y-local-collector.yaml",
         "runtime/codex-o11y.env",
+        "runtime/codex-notify-galileo-handoff.md",
         "bin/codex-o11y-exec",
         "bin/codex-o11y-jsonl-to-spans.py",
         "hooks/hooks.json",
@@ -985,8 +1118,10 @@ def validate_output(output_dir: Path, json_output: bool = False) -> dict[str, An
                 errors.append("direct profile missing Splunk OTLP trace or metric endpoints")
             if '"X-SF-TOKEN" = "${SPLUNK_ACCESS_TOKEN}"' not in text:
                 errors.append("direct profile missing safe X-SF-TOKEN environment placeholder")
-        if profile.name.endswith("local.config.toml") and "http://127.0.0.1:14318" not in text:
-            errors.append("local profile missing loopback collector endpoint")
+        if profile.name.endswith("local.config.toml") and (
+            "/v1/traces" not in text or "/v1/metrics" not in text
+        ):
+            errors.append("local profile missing local collector trace or metric endpoints")
 
     if (output_dir / "collector/codex-o11y-local-collector.yaml").exists():
         values = (output_dir / "collector/codex-o11y-local-collector.yaml").read_text(encoding="utf-8")
@@ -1164,6 +1299,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--service-name", default="")
     parser.add_argument("--realm", default="")
     parser.add_argument("--destination", choices=sorted(VALID_DESTINATIONS), default="")
+    parser.add_argument("--local-collector-endpoint", default="")
     parser.add_argument("--external-trace-endpoint", default="")
     parser.add_argument("--external-metric-endpoint", default="")
     parser.add_argument("--external-log-endpoint", default="")

--- a/skills/splunk-observability-codex-instrumentation-setup/SKILL.md
+++ b/skills/splunk-observability-codex-instrumentation-setup/SKILL.md
@@ -14,7 +14,9 @@ settings in project `.codex/config.toml`.
 
 The skill renders three destination profiles:
 
-- `local-collector`: traces and metrics to `http://127.0.0.1:14318`.
+- `local-collector`: traces and metrics to
+  `http://127.0.0.1:14318` by default. Override the base endpoint with
+  `--local-collector-endpoint http://localhost:14318`.
 - `external-collector`: traces, metrics, and optional native logs to explicit
   external OTLP collector endpoints.
 - `direct`: traces to
@@ -24,6 +26,12 @@ The skill renders three destination profiles:
 
 Direct native Codex logs are refused. Native logs are allowed only through local
 or external collector destinations.
+
+For Galileo Observe, do not assume a configured Galileo MCP server means Codex
+turns are being logged. MCP enables tool access only. Interactive Codex turn
+logging needs a separate `notify`-based bridge that runs after `turn-ended`,
+parses the local Codex session JSONL, and writes a Galileo `codex.turn` trace
+through the Galileo trace ingest API.
 
 ## Safety Rules
 
@@ -40,6 +48,10 @@ or external collector destinations.
   `--accept-content-capture`.
 - AI Defense content inspection requires `--enable-ai-defense` plus
   `--accept-ai-defense-content-inspection`.
+- Galileo turn mirroring must be fail-soft and secret-file based. The notifier
+  should read the Galileo key from a file, redact obvious secrets/high-entropy
+  values, write local non-secret failure evidence, and exit `0` if Galileo is
+  unavailable.
 
 ## Primary Workflow
 
@@ -49,6 +61,7 @@ Render local collector assets:
 bash skills/splunk-observability-codex-instrumentation-setup/scripts/setup.sh \
   --render \
   --destination local-collector \
+  --local-collector-endpoint http://localhost:14318 \
   --realm us0 \
   --output-dir splunk-observability-codex-instrumentation-rendered
 ```
@@ -108,6 +121,10 @@ bash skills/splunk-observability-codex-instrumentation-setup/scripts/setup.sh \
   wrapper.
 - `hooks/hooks.json` and `hooks/codex-o11y-stop-hook.py`: optional fail-soft
   interactive Stop hook.
+- `runtime/codex-notify-galileo-handoff.md`: companion handoff for sending
+  completed Codex turns into Galileo Observe. It documents the `notify`
+  strategy, trace shape, secret handling, duplicate suppression, and read-back
+  validation using `traces/count` plus `export_records`.
 - `apply-plan.json`, `coverage-report.json`, `coverage-report.md`,
   `doctor-report.md`, and `handoff.md`.
 

--- a/skills/splunk-observability-codex-instrumentation-setup/reference.md
+++ b/skills/splunk-observability-codex-instrumentation-setup/reference.md
@@ -22,9 +22,11 @@ Rendered file:
   `http://127.0.0.1:14318`. Override with
   `--local-collector-endpoint http://localhost:14318` or the spec key
   `codex.local_collector_endpoint`.
-- The endpoint must be an `http://` or `https://` base URL with an explicit
-  port, no credentials, and no `/v1/...` path. The renderer appends
-  `/v1/traces`, `/v1/metrics`, and `/v1/logs` as needed.
+- The endpoint must be an `http://` base URL with an explicit port, no
+  credentials, and no `/v1/...` path. The rendered collector receiver is plain
+  OTLP HTTP, so `https://` is rejected unless future TLS receiver rendering is
+  added. The renderer appends `/v1/traces`, `/v1/metrics`, and `/v1/logs` as
+  needed.
 - `trace_exporter` is an `otlp-http` inline exporter table
 - `metrics_exporter` is an `otlp-http` inline exporter table
 - default trace endpoint: `http://127.0.0.1:14318/v1/traces`

--- a/skills/splunk-observability-codex-instrumentation-setup/reference.md
+++ b/skills/splunk-observability-codex-instrumentation-setup/reference.md
@@ -18,15 +18,25 @@
 Rendered file:
 `profiles/codex-o11y-local.config.toml`
 
+- Base endpoint: `local_collector_endpoint`, default
+  `http://127.0.0.1:14318`. Override with
+  `--local-collector-endpoint http://localhost:14318` or the spec key
+  `codex.local_collector_endpoint`.
+- The endpoint must be an `http://` or `https://` base URL with an explicit
+  port, no credentials, and no `/v1/...` path. The renderer appends
+  `/v1/traces`, `/v1/metrics`, and `/v1/logs` as needed.
 - `trace_exporter` is an `otlp-http` inline exporter table
 - `metrics_exporter` is an `otlp-http` inline exporter table
-- trace endpoint: `http://127.0.0.1:14318/v1/traces`
-- metric endpoint: `http://127.0.0.1:14318/v1/metrics`
-- native log endpoint, when enabled: `http://127.0.0.1:14318/v1/logs`
+- default trace endpoint: `http://127.0.0.1:14318/v1/traces`
+- default metric endpoint: `http://127.0.0.1:14318/v1/metrics`
+- default native log endpoint, when enabled:
+  `http://127.0.0.1:14318/v1/logs`
 - native log exporter remains `none` unless `--enable-native-logs` is set
 - collector overlay exports traces through OTLP/HTTP APM ingest, metrics through
   SignalFx with `send_otlp_histograms: true`, adds a logs pipeline when native
-  logs are enabled, and reads the token with `${env:SPLUNK_ACCESS_TOKEN}`
+  logs are enabled, binds its OTLP HTTP receiver to the host and port parsed
+  from `local_collector_endpoint`, and reads the token with
+  `${env:SPLUNK_ACCESS_TOKEN}`
 
 ### External Collector
 
@@ -88,6 +98,65 @@ managed Codex O11y Stop hook is replaced.
 `--output-dir`. This prevents an apply-only command from re-rendering the output
 with default options and installing a different profile than the operator
 reviewed.
+
+## Interactive Notify Bridge
+
+Codex has two different telemetry surfaces that are easy to conflate:
+
+- Native `[otel]` profile export sends Codex-managed traces, metrics, and
+  optionally native logs to the configured OTel destination. If
+  `[otel].exporter = "none"`, native log export is disabled.
+- `notify = [...]` runs an operator command when a Codex turn ends. It can be
+  used as a fail-soft post-turn bridge even when native `[otel]` log export is
+  disabled.
+
+Use `notify` for Galileo Observe turn mirroring. A configured Galileo MCP
+server only exposes Galileo tools to Codex; it does not automatically populate
+Galileo log streams with Codex turns.
+
+The proven bridge shape is:
+
+1. Keep the existing notifier chain intact when one exists.
+2. Run a background Python logger from the notifier on `turn-ended`.
+3. Parse the local Codex session JSONL under
+   `CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl`, preferring a session path
+   from the notify payload when Codex supplies one.
+4. Build one Galileo trace named `codex.turn` for the completed turn.
+5. Add one LLM child span for the turn and child spans for tool calls and web
+   retrievals when present.
+6. Read the Galileo API key from `GALILEO_API_KEY_FILE`; never pass it on argv.
+7. Suppress duplicates with a local state file such as
+   `CODEX_HOME/log/codex-galileo-emitted-turns.json`.
+8. Log non-secret failures to `CODEX_HOME/log/codex-galileo-notify.log` and
+   exit `0` so telemetry does not block Codex.
+
+For Galileo direct ingest, call:
+
+```text
+POST /v2/projects/{project_id}/traces
+```
+
+Use `reliable=true` and `include_trace_ids=true`. The response should include
+`records_count`, `traces_count`, `spans_count`, and `trace_ids`.
+
+Verify persistence, not just API acceptance, with:
+
+```text
+POST /v2/projects/{project_id}/traces/count
+POST /v2/projects/{project_id}/export_records
+```
+
+Filter both calls by the returned trace ID. A successful export returns a
+`codex.turn` trace with `tags=["codex","codex-cli","turn-ended"]`.
+
+Galileo `user_metadata` values must be strings. Convert values such as
+`tool_count`, `retrieval_count`, booleans, and numeric IDs before sending the
+payload. A non-string metadata value returns HTTP `422`.
+
+Prompt, response, tool argument, and tool output capture is content capture. Use
+metadata-only placeholders by default, or require explicit operator acceptance
+before sending content to Galileo. Always redact obvious secrets, bearer
+tokens, JWTs, and high-entropy strings before exporting any captured text.
 
 ## Strict Config
 

--- a/skills/splunk-observability-codex-instrumentation-setup/template.example
+++ b/skills/splunk-observability-codex-instrumentation-setup/template.example
@@ -12,7 +12,7 @@
     "accept_content_capture": false,
     "enable_ai_defense": false,
     "accept_ai_defense_content_inspection": false,
-    "local_collector_endpoint": "http://127.0.0.1:14318",
+    "local_collector_endpoint": "http://localhost:14318",
     "external_collector_protocol": "otlp-http",
     "external_trace_endpoint": "",
     "external_metric_endpoint": "",
@@ -23,4 +23,3 @@
     "external_tls": {}
   }
 }
-

--- a/tests/test_galileo_platform_setup.py
+++ b/tests/test_galileo_platform_setup.py
@@ -94,6 +94,7 @@ def test_default_render_emits_plan_coverage_and_handoff_scripts(tmp_path: Path) 
     assert (output_dir / "lifecycle/product-coverage-matrix.json").is_file()
     assert (output_dir / "lifecycle/product-coverage-matrix.md").is_file()
     assert (output_dir / "runtime/python-opentelemetry-env.sh").is_file()
+    assert (output_dir / "runtime/codex-notify-galileo-handoff.md").is_file()
     assert (output_dir / "runtime/python-galileo-protect.py").is_file()
     assert (output_dir / "evaluate/evaluate-assets.yaml").is_file()
     assert (output_dir / "evaluate/multimodal-metrics-handoff.yaml").is_file()
@@ -122,6 +123,7 @@ def test_default_render_emits_plan_coverage_and_handoff_scripts(tmp_path: Path) 
         "Luna Studio UI and SDK training lifecycle",
         "Provider integrations, model aliases, costs, and pricing",
         "Provider integration selection, status, and Databricks helpers",
+        "Codex notify turn logging",
         "Tags, metadata, run labels, and filter hygiene",
         "Enterprise data retention, TTL, redaction, and privacy controls",
         "Trace query, columns, recompute, update, and delete maintenance",
@@ -147,6 +149,10 @@ def test_default_render_emits_plan_coverage_and_handoff_scripts(tmp_path: Path) 
         "Splunk destinations",
     ]:
         assert surface in surfaces
+    codex_notify = (output_dir / "runtime/codex-notify-galileo-handoff.md").read_text(encoding="utf-8")
+    assert "Galileo MCP server" in codex_notify
+    assert "POST /v2/projects/{project_id}/traces" in codex_notify
+    assert "traces/count" in codex_notify
     for script in [
         "apply-readiness.sh",
         "apply-object-lifecycle.sh",

--- a/tests/test_splunk_observability_coding_agent_instrumentation.py
+++ b/tests/test_splunk_observability_coding_agent_instrumentation.py
@@ -143,6 +143,19 @@ def test_codex_local_collector_endpoint_rejects_full_signal_path(tmp_path: Path)
     assert "base URL" in result.stdout + result.stderr
 
 
+def test_codex_local_collector_endpoint_rejects_https_without_tls_receiver(tmp_path: Path) -> None:
+    result = run_codex(
+        "--render",
+        "--local-collector-endpoint",
+        "https://localhost:14318",
+        "--output-dir",
+        str(tmp_path / "bad-local-https-endpoint"),
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "plain OTLP HTTP" in result.stdout + result.stderr
+
+
 def test_codex_external_collector_http_and_grpc_profiles(tmp_path: Path) -> None:
     http_out = tmp_path / "http"
     run_codex(

--- a/tests/test_splunk_observability_coding_agent_instrumentation.py
+++ b/tests/test_splunk_observability_coding_agent_instrumentation.py
@@ -106,6 +106,43 @@ def test_codex_local_direct_and_external_profiles_render_valid_toml(tmp_path: Pa
     assert 'exporter = "none"' in direct_text
 
 
+def test_codex_local_collector_endpoint_is_configurable(tmp_path: Path) -> None:
+    out = tmp_path / "custom-localhost"
+    run_codex(
+        "--render",
+        "--destination",
+        "local-collector",
+        "--local-collector-endpoint",
+        "http://localhost:24318",
+        "--enable-native-logs",
+        "--output-dir",
+        str(out),
+    )
+
+    profile = (out / "profiles/codex-o11y-local.config.toml").read_text(encoding="utf-8")
+    assert "http://localhost:24318/v1/traces" in profile
+    assert "http://localhost:24318/v1/metrics" in profile
+    assert "http://localhost:24318/v1/logs" in profile
+
+    overlay = (out / "collector/codex-o11y-local-collector.yaml").read_text(encoding="utf-8")
+    assert 'endpoint: "localhost:24318"' in overlay
+
+    run_codex("--validate", "--output-dir", str(out))
+
+
+def test_codex_local_collector_endpoint_rejects_full_signal_path(tmp_path: Path) -> None:
+    result = run_codex(
+        "--render",
+        "--local-collector-endpoint",
+        "http://localhost:14318/v1/traces",
+        "--output-dir",
+        str(tmp_path / "bad-local-endpoint"),
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "base URL" in result.stdout + result.stderr
+
+
 def test_codex_external_collector_http_and_grpc_profiles(tmp_path: Path) -> None:
     http_out = tmp_path / "http"
     run_codex(
@@ -243,6 +280,7 @@ def test_codex_reports_apply_plan_strict_config_hooks_and_histograms(tmp_path: P
         "bin/codex-o11y-jsonl-to-spans.py",
         "hooks/hooks.json",
         "hooks/codex-o11y-stop-hook.py",
+        "runtime/codex-notify-galileo-handoff.md",
     ]
     for rel in required:
         assert (out / rel).is_file(), rel
@@ -278,6 +316,11 @@ def test_codex_reports_apply_plan_strict_config_hooks_and_histograms(tmp_path: P
     assert "send_otlp_histograms: true" in (out / "collector/codex-o11y-local-collector.yaml").read_text(
         encoding="utf-8"
     )
+    galileo_handoff = (out / "runtime/codex-notify-galileo-handoff.md").read_text(encoding="utf-8")
+    assert "Galileo MCP server" in galileo_handoff
+    assert "POST /v2/projects/{project_id}/traces" in galileo_handoff
+    assert "user_metadata" in galileo_handoff
+    assert "traces/count" in galileo_handoff
 
 
 def test_codex_apply_uses_concrete_codex_home_installs_runtime_and_merges_hooks(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Add Galileo Observe notify handoff documentation and rendered runtime artifact for Codex turn logging.
- Add configurable Codex local collector endpoint support via `--local-collector-endpoint` / `codex.local_collector_endpoint`.
- Update Codex instrumentation docs, template, validation behavior, and regression coverage.
- Include Galileo platform logging updates already present in the local change set.

## Validation

- `python3 -m pytest tests/test_galileo_platform_setup.py tests/test_splunk_observability_coding_agent_instrumentation.py`
- `git diff --check`

## Notes

Direct push to `main` is blocked by repository rules requiring status checks, so this PR carries the local `main` commit into the protected branch workflow.