### PR TITLE
[codex] Add Galileo Luna scorer configuration

### DIFF
--- a/skills/galileo-platform-setup/SKILL.md
+++ b/skills/galileo-platform-setup/SKILL.md
@@ -44,27 +44,31 @@ logic.
    observability from multi-model experiment comparison: this skill supports
    both, with first-class multimodal assets under `multimodal/` and
    multi-model comparison guidance under `evaluate/experiment-handoff.md`.
-3. **Observe export to Splunk HEC**: render and run
+3. **Luna scorer settings**: inventory available Luna/SLM preset scorers,
+   replace mapped OpenAI/LLM-backed log-stream metric settings with Luna/SLM
+   preset or custom scorer IDs using `scripts/galileo_luna_scorers.py`, preserve
+   unmapped scorers, and optionally request metric recomputation.
+4. **Observe export to Splunk HEC**: render and run
    `scripts/galileo_to_splunk_hec.py` against
    `/v2/projects/{project_id}/export_records` using JSONL by default.
-4. **Observe runtime**: render Python and Kubernetes Galileo
+5. **Observe runtime**: render Python and Kubernetes Galileo
    OpenTelemetry/OpenInference snippets.
    For Codex itself, use the rendered `runtime/codex-notify-galileo-handoff.md`
    guidance: Galileo MCP connectivity does not automatically populate Observe
    log streams, so interactive Codex turn logging requires a separate
    `notify`-based bridge that writes `codex.turn` traces through Galileo direct
    trace ingest.
-5. **Protect runtime**: render a file-secret-backed legacy Python helper for
+6. **Protect runtime**: render a file-secret-backed legacy Python helper for
    `/v2/protect/invoke` where an existing deployment still uses Protect.
-6. **Evaluate assets**: render handoffs for experiments, datasets, metrics
+7. **Evaluate assets**: render handoffs for experiments, datasets, metrics
    testing, annotations, feedback, Signals, and Trends.
-7. **Multimodal observability**: render GalileoLogger, file/upload,
+8. **Multimodal observability**: render GalileoLogger, file/upload,
    LangChain/LangGraph, multimodal quality metric, Splunk metadata-only export,
    and validation-search handoffs for image, audio, and PDF/document traces.
-8. **Agent Observability Controls**: render console inventory, Log stream
+9. **Agent Observability Controls**: render console inventory, Log stream
    attachment, control-span export, and Splunk search evidence handoffs without
    claiming undocumented control CRUD API support.
-9. **Splunk handoffs**:
+10. **Splunk handoffs**:
    - HEC token/service: `splunk-hec-service-setup`
    - Splunk Platform OTLP input: `splunk-connect-for-otlp-setup`
    - Splunk OTel Collector: `splunk-observability-otel-collector-setup`
@@ -140,6 +144,7 @@ Apply sections:
 
 - `readiness`
 - `object-lifecycle`
+- `luna-scorers`
 - `observe-export`
 - `observe-runtime`
 - `protect-runtime`
@@ -153,15 +158,19 @@ Apply sections:
 - `detectors`
 
 With `--o11y-only`, the default selected sections are `readiness`,
-`object-lifecycle`, `observe-runtime`, `protect-runtime`, `evaluate-assets`,
-`multimodal-assets`, `observability-controls`, `otel-collector`, `dashboards`,
-and `detectors`.
+`object-lifecycle`, `luna-scorers`, `observe-runtime`, `protect-runtime`,
+`evaluate-assets`, `multimodal-assets`, `observability-controls`,
+`otel-collector`, `dashboards`, and `detectors`.
 Explicit Splunk Platform sections (`observe-export`, `splunk-hec`,
 `splunk-otlp`) are rejected in that mode.
 
 Use `--lifecycle-manifest`, `--dataset-dir`, `--prompt-manifest`,
 `--experiment-manifest`, `--protect-stage-manifest`, and `--metrics` when the
 tenant needs Galileo objects provisioned before export or runtime handoff.
+Use `--luna-list-only true` to inventory current and available scorers without
+patching metric settings. Use `--luna-scorer-map`, `--luna-recompute true`, and
+`--luna-strict true` when replacing preset LLM judge scorers with Luna/SLM
+preset or custom scorer IDs.
 
 ## Codex Turn Logging Note
 

--- a/skills/galileo-platform-setup/reference.md
+++ b/skills/galileo-platform-setup/reference.md
@@ -34,6 +34,7 @@ schema, HEC envelope shape, or collector handoff flags.
 | --- | --- | --- |
 | `readiness` | `galileo-platform-setup` | Render endpoint derivation, `/v2/healthcheck`, auth/RBAC/Luna/Protect/Evaluate coverage checks. |
 | `object-lifecycle` | `galileo-platform-setup` | Create or validate Galileo projects, log streams, datasets, prompts, experiments, metrics, Protect stages, and Agent Control target resolution. |
+| `luna-scorers` | `galileo-platform-setup` | Inventory Luna/SLM scorers, PATCH log-stream metric settings for mapped scorers, preserve unavailable targets, and optionally recompute metrics. |
 | `observe-export` | `galileo-platform-setup` | Pull Galileo records through `export_records` and send HEC JSON events. |
 | `observe-runtime` | `galileo-platform-setup` | Provide Python and Kubernetes OTel/OpenInference bootstrap snippets. |
 | `protect-runtime` | `galileo-platform-setup` | Provide a legacy Python `/v2/protect/invoke` helper for existing Protect users. |
@@ -54,6 +55,7 @@ default render/apply selects only:
 
 - `readiness`
 - `object-lifecycle`
+- `luna-scorers`
 - `observe-runtime`
 - `protect-runtime`
 - `evaluate-assets`
@@ -88,10 +90,36 @@ Lifecycle inputs:
 Rendered lifecycle assets:
 
 - `lifecycle/object-lifecycle-manifest.example.json`
+- `lifecycle/luna-scorer-map.example.json`
 - `lifecycle/product-coverage-matrix.json`
 - `lifecycle/product-coverage-matrix.md`
 - `scripts/apply-object-lifecycle.sh`
+- `scripts/apply-luna-scorers.sh`
 - `scripts/galileo_object_lifecycle.py`
+- `scripts/galileo_luna_scorers.py`
+
+## Luna Scorer Settings
+
+Use `luna-scorers` after `object-lifecycle` has created or validated the
+project and log stream. The default `lifecycle/luna-scorer-map.example.json`
+maps common LLM-backed preset metric names to matching Luna/SLM preset names
+where the tenant exposes them. Missing targets are preserved by default so a
+partial tenant rollout does not remove existing columns.
+
+Operator controls:
+
+- `--luna-list-only true`: inventory current log-stream scorers and available
+  SLM scorers without PATCHing metric settings.
+- `--luna-scorer-map PATH`: provide a JSON map with `replacements` entries of
+  `{ "from": "metric_name", "to": "metric_name_luna" }`.
+- `remove: true`: optional replacement flag to drop a known-bad scorer from
+  metric settings when no replacement should be enabled.
+- `custom_luna_scorer_ids`: optional entries in the map with `from`, `to_id`,
+  `scorer_type`, and `model_type` for custom registered Luna scorer IDs.
+- `--luna-strict true`: fail instead of preserving a scorer when a requested
+  Luna target is unavailable.
+- `--luna-recompute true`: call Galileo recompute-metrics for attached scorer
+  IDs after a successful settings update.
 
 Product coverage surfaces tracked in the matrix:
 

--- a/skills/galileo-platform-setup/scripts/galileo_luna_scorers.py
+++ b/skills/galileo-platform-setup/scripts/galileo_luna_scorers.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""Attach Luna/SLM-backed Galileo scorers to a log stream.
+
+The script uses Galileo's documented v2 scorer and metric-settings APIs. It is
+secret-file based and never prints the API key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+from urllib import error, request
+
+
+DEFAULT_REPLACEMENTS = [
+    {"from": "correctness", "to": "correctness_luna"},
+    {"from": "completeness", "to": "completeness_luna"},
+    {"from": "instruction_adherence", "to": "instruction_adherence_luna"},
+    {"from": "tool_selection_quality", "to": "tool_selection_quality_luna"},
+    {"from": "tool_error_rate", "to": "tool_error_rate_luna"},
+    {"from": "agent_efficiency", "to": "agent_efficiency_luna"},
+]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--galileo-api-key-file", required=True)
+    parser.add_argument("--api-base", default="https://api.galileo.ai")
+    parser.add_argument("--project-id", default="")
+    parser.add_argument("--log-stream-id", default="")
+    parser.add_argument("--lifecycle-result", default="")
+    parser.add_argument("--scorer-map", default="")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--list-only", action="store_true")
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--recompute", action="store_true")
+    parser.add_argument("--recompute-limit", type=int, default=100)
+    return parser.parse_args(argv)
+
+
+def read_secret_file(path: str) -> str:
+    secret_path = Path(path).expanduser()
+    if not secret_path.is_file():
+        raise SystemExit(f"ERROR: Galileo API key file is not readable: {secret_path}")
+    value = secret_path.read_text(encoding="utf-8").strip()
+    if not value:
+        raise SystemExit(f"ERROR: Galileo API key file is empty: {secret_path}")
+    return value
+
+
+def load_json_file(path: str) -> dict[str, Any]:
+    if not path:
+        return {}
+    file_path = Path(path).expanduser()
+    if not file_path.is_file():
+        raise SystemExit(f"ERROR: Scorer map file not found: {file_path}")
+    data = json.loads(file_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit("ERROR: Scorer map must be a JSON object")
+    return data
+
+
+def truthy(value: Any) -> bool:
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def normalize_replacements(config: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = config.get("replacements") or config.get("scorers") or DEFAULT_REPLACEMENTS
+    replacements: list[dict[str, Any]] = []
+    if isinstance(raw, dict):
+        raw = [{"from": key, "to": value} for key, value in raw.items()]
+    if not isinstance(raw, list):
+        raise SystemExit("ERROR: Scorer replacements must be a list or mapping")
+    for item in raw:
+        if not isinstance(item, dict):
+            raise SystemExit("ERROR: Each scorer replacement must be an object")
+        source = str(item.get("from") or item.get("source") or item.get("name") or "").strip()
+        target = str(item.get("to") or item.get("target") or item.get("to_name") or "").strip()
+        target_id = str(item.get("to_id") or item.get("target_id") or item.get("id") or "").strip()
+        if not source:
+            raise SystemExit("ERROR: Scorer replacement is missing a from/source name")
+        if not target and not target_id and not truthy(item.get("remove", False)):
+            raise SystemExit(f"ERROR: Scorer replacement for {source} is missing to/to_id")
+        normalized = dict(item)
+        normalized["from"] = source
+        if truthy(item.get("remove", False)):
+            normalized["remove"] = True
+        if target:
+            normalized["to"] = target
+        if target_id:
+            normalized["to_id"] = target_id
+        replacements.append(normalized)
+    for item in config.get("custom_luna_scorer_ids") or []:
+        if not isinstance(item, dict):
+            raise SystemExit("ERROR: custom_luna_scorer_ids entries must be objects")
+        if not str(item.get("to_id") or item.get("target_id") or item.get("id") or "").strip():
+            continue
+        source = str(item.get("from") or item.get("source") or item.get("name") or "").strip()
+        if not source:
+            raise SystemExit("ERROR: custom_luna_scorer_ids entry is missing from/source")
+        normalized = dict(item)
+        normalized["from"] = source
+        normalized["to_id"] = str(item.get("to_id") or item.get("target_id") or item.get("id")).strip()
+        normalized.setdefault("scorer_type", "luna")
+        normalized.setdefault("model_type", "slm")
+        replacements.append(normalized)
+    return replacements
+
+
+class GalileoClient:
+    def __init__(self, api_base: str, api_key: str) -> None:
+        self.api_base = api_base.rstrip("/")
+        self.api_key = api_key
+
+    def request_json(self, method: str, path: str, body: Any | None = None) -> Any:
+        data = None if body is None else json.dumps(body).encode("utf-8")
+        req = request.Request(
+            self.api_base + path,
+            method=method,
+            data=data,
+            headers={
+                "Content-Type": "application/json",
+                "Galileo-API-Key": self.api_key,
+            },
+        )
+        try:
+            with request.urlopen(req, timeout=60) as response:
+                text = response.read().decode("utf-8")
+        except error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"{method} {path} failed with HTTP {exc.code}: {detail}") from exc
+        if not text:
+            return {}
+        return json.loads(text)
+
+    def metric_settings(self, project_id: str, log_stream_id: str) -> dict[str, Any]:
+        return self.request_json(
+            "GET",
+            f"/v2/projects/{project_id}/log_streams/{log_stream_id}/metric_settings",
+        )
+
+    def patch_metric_settings(
+        self,
+        project_id: str,
+        log_stream_id: str,
+        body: dict[str, Any],
+    ) -> dict[str, Any]:
+        return self.request_json(
+            "PATCH",
+            f"/v2/projects/{project_id}/log_streams/{log_stream_id}/metric_settings",
+            body,
+        )
+
+    def list_scorers(self, filters: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        payload = {"filters": filters}
+        response = self.request_json("POST", "/v2/scorers/list", payload)
+        scorers = response.get("scorers", [])
+        if not isinstance(scorers, list):
+            raise RuntimeError("Unexpected scorer list response shape")
+        return [item for item in scorers if isinstance(item, dict)]
+
+    def recompute_metrics(
+        self,
+        project_id: str,
+        log_stream_id: str,
+        scorer_ids: list[str],
+        limit: int,
+    ) -> Any:
+        return self.request_json(
+            "POST",
+            f"/v2/projects/{project_id}/recompute-metrics",
+            {
+                "log_stream_id": log_stream_id,
+                "scorer_ids": scorer_ids,
+                "limit": limit,
+                "starting_token": 0,
+            },
+        )
+
+
+def scorer_identity(scorer: dict[str, Any]) -> dict[str, Any]:
+    latest = scorer.get("latest_version") or {}
+    default = scorer.get("default_version") or {}
+    return {
+        "id": scorer.get("id"),
+        "name": scorer.get("name"),
+        "label": scorer.get("label"),
+        "scorer_type": scorer.get("scorer_type"),
+        "model_type": scorer.get("model_type"),
+        "input_type": scorer.get("input_type") or latest.get("input_type") or default.get("input_type"),
+        "output_type": scorer.get("output_type") or latest.get("output_type") or default.get("output_type"),
+        "default_version_id": scorer.get("default_version_id"),
+        "latest_version_id": latest.get("id"),
+    }
+
+
+def index_scorers_by_name(client: GalileoClient, target_names: list[str]) -> dict[str, dict[str, Any]]:
+    if not target_names:
+        return {}
+    scorers = client.list_scorers(
+        [
+            {
+                "name": "name",
+                "operator": "one_of",
+                "value": sorted(set(target_names)),
+            }
+        ]
+    )
+    return {str(scorer.get("name")): scorer for scorer in scorers if scorer.get("name")}
+
+
+def slm_inventory(client: GalileoClient) -> list[dict[str, Any]]:
+    return [
+        scorer_identity(item)
+        for item in client.list_scorers([{"name": "model_type", "operator": "eq", "value": "slm"}])
+    ]
+
+
+def scorer_config_from_target(
+    current: dict[str, Any],
+    replacement: dict[str, Any],
+    target: dict[str, Any] | None,
+) -> dict[str, Any]:
+    target_id = replacement.get("to_id") or (target or {}).get("id")
+    if not target_id:
+        raise RuntimeError(f"Replacement target for {replacement['from']} has no scorer id")
+
+    config: dict[str, Any] = {
+        "id": target_id,
+        "scorer_type": replacement.get("scorer_type") or (target or {}).get("scorer_type") or "preset",
+    }
+    optional_fields = [
+        "filters",
+        "cot_enabled",
+        "num_judges",
+        "scoreable_node_types",
+        "roll_up_method",
+    ]
+    for field in optional_fields:
+        value = replacement.get(field)
+        if value is None:
+            value = (target or {}).get(field)
+        if value is None:
+            value = current.get(field)
+        if value is not None:
+            config[field] = value
+
+    name = replacement.get("to") or replacement.get("to_name") or (target or {}).get("name")
+    if name:
+        config["name"] = name
+    model_type = replacement.get("model_type") or (target or {}).get("model_type") or "slm"
+    if model_type:
+        config["model_type"] = model_type
+    output_type = replacement.get("output_type") or (target or {}).get("output_type") or current.get("output_type")
+    if output_type:
+        config["output_type"] = output_type
+    input_type = replacement.get("input_type") or (target or {}).get("input_type") or current.get("input_type")
+    if input_type:
+        config["input_type"] = input_type
+    model_name = replacement.get("model_name") or (target or {}).get("model_name")
+    if model_name:
+        config["model_name"] = model_name
+    return config
+
+
+def build_metric_settings_plan(
+    settings: dict[str, Any],
+    replacements: list[dict[str, Any]],
+    targets_by_name: dict[str, dict[str, Any]],
+    strict: bool,
+) -> dict[str, Any]:
+    current_scorers = [item for item in settings.get("scorers", []) if isinstance(item, dict)]
+    replacements_by_source = {item["from"]: item for item in replacements}
+    new_scorers: list[dict[str, Any]] = []
+    applied: list[dict[str, Any]] = []
+    unavailable: list[dict[str, Any]] = []
+    preserved: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+
+    for scorer in current_scorers:
+        name = str(scorer.get("name") or "")
+        replacement = replacements_by_source.get(name)
+        if not replacement:
+            preserved.append(scorer_identity(scorer))
+            scorer_id = str(scorer.get("id") or "")
+            if scorer_id and scorer_id not in seen_ids:
+                new_scorers.append(scorer)
+                seen_ids.add(scorer_id)
+            continue
+
+        if replacement.get("remove"):
+            applied.append(
+                {
+                    "from": scorer_identity(scorer),
+                    "to": None,
+                    "status": "removed",
+                }
+            )
+            continue
+
+        target = targets_by_name.get(str(replacement.get("to") or ""))
+        if not target and not replacement.get("to_id"):
+            unavailable.append(
+                {
+                    "from": name,
+                    "requested_target": replacement.get("to"),
+                    "reason": "target_scorer_not_found",
+                }
+            )
+            preserved.append(scorer_identity(scorer))
+            scorer_id = str(scorer.get("id") or "")
+            if scorer_id and scorer_id not in seen_ids:
+                new_scorers.append(scorer)
+                seen_ids.add(scorer_id)
+            continue
+
+        next_config = scorer_config_from_target(scorer, replacement, target)
+        next_id = str(next_config.get("id") or "")
+        if next_id in seen_ids:
+            applied.append(
+                {
+                    "from": scorer_identity(scorer),
+                    "to": scorer_identity(target or next_config),
+                    "status": "deduplicated_target_already_enabled",
+                }
+            )
+            continue
+        new_scorers.append(next_config)
+        seen_ids.add(next_id)
+        applied.append(
+            {
+                "from": scorer_identity(scorer),
+                "to": scorer_identity(target or next_config),
+                "status": "planned",
+            }
+        )
+
+    errors = []
+    if strict and unavailable:
+        errors.append("strict mode requested but one or more Luna scorer targets were not found")
+
+    patch_body = {
+        "scorers": new_scorers,
+        "segment_filters": settings.get("segment_filters"),
+    }
+    return {
+        "patch_body": patch_body,
+        "applied": applied,
+        "unavailable": unavailable,
+        "preserved": preserved,
+        "errors": errors,
+    }
+
+
+def write_result(path: str, payload: dict[str, Any]) -> None:
+    output = Path(path).expanduser()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def resolve_ids(args: argparse.Namespace) -> tuple[str, str]:
+    project_id = str(args.project_id or "").strip()
+    log_stream_id = str(args.log_stream_id or "").strip()
+    if project_id and log_stream_id:
+        return project_id, log_stream_id
+    if args.lifecycle_result:
+        path = Path(args.lifecycle_result).expanduser()
+        if path.is_file():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            project = data.get("project") or {}
+            log_stream = data.get("log_stream") or {}
+            project_id = project_id or str(project.get("id") or "").strip()
+            log_stream_id = log_stream_id or str(log_stream.get("id") or "").strip()
+    missing = []
+    if not project_id:
+        missing.append("project_id")
+    if not log_stream_id:
+        missing.append("log_stream_id")
+    if missing:
+        raise SystemExit(
+            "ERROR: Missing "
+            + ", ".join(missing)
+            + ". Pass --project-id/--log-stream-id or --lifecycle-result from object-lifecycle."
+        )
+    return project_id, log_stream_id
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    map_config = load_json_file(args.scorer_map)
+    replacements = normalize_replacements(map_config)
+    strict = args.strict or truthy(map_config.get("strict", False))
+    list_only = args.list_only or truthy(map_config.get("list_only", False))
+    recompute = args.recompute or truthy(map_config.get("recompute", False))
+    api_key = read_secret_file(args.galileo_api_key_file)
+    client = GalileoClient(args.api_base, api_key)
+    project_id, log_stream_id = resolve_ids(args)
+
+    result: dict[str, Any] = {
+        "api_version": "galileo-platform-setup/luna-scorer-settings-result/v1",
+        "secret_values_rendered": False,
+        "dry_run": args.dry_run,
+        "list_only": list_only,
+        "project_id": project_id,
+        "log_stream_id": log_stream_id,
+        "replacements": replacements,
+        "status": "ok",
+        "errors": [],
+    }
+    try:
+        settings = client.metric_settings(project_id, log_stream_id)
+        target_names = [str(item.get("to") or "") for item in replacements if item.get("to")]
+        targets_by_name = index_scorers_by_name(client, target_names)
+        result["current_scorers"] = [scorer_identity(item) for item in settings.get("scorers", [])]
+        result["available_slm_scorers"] = slm_inventory(client)
+        result["target_scorers"] = {
+            name: scorer_identity(scorer) for name, scorer in sorted(targets_by_name.items())
+        }
+        if list_only:
+            write_result(args.output, result)
+            print(json.dumps(result, indent=2, sort_keys=True))
+            return 0
+
+        plan = build_metric_settings_plan(settings, replacements, targets_by_name, strict)
+        result.update(
+            {
+                "planned_replacements": plan["applied"],
+                "unavailable_replacements": plan["unavailable"],
+                "preserved_scorers": plan["preserved"],
+                "patch_body": plan["patch_body"] if args.dry_run else {"redacted": "written_to_output_summary_only"},
+            }
+        )
+        if plan["errors"]:
+            result["status"] = "error"
+            result["errors"] = plan["errors"]
+            write_result(args.output, result)
+            print(json.dumps(result, indent=2, sort_keys=True))
+            return 1
+        if not plan["applied"]:
+            result["status"] = "no_changes"
+            write_result(args.output, result)
+            print(json.dumps(result, indent=2, sort_keys=True))
+            return 0
+        if args.dry_run:
+            result["status"] = "planned"
+            write_result(args.output, result)
+            print(json.dumps(result, indent=2, sort_keys=True))
+            return 0
+
+        updated = client.patch_metric_settings(project_id, log_stream_id, plan["patch_body"])
+        result["status"] = "updated"
+        result["updated_scorers"] = [scorer_identity(item) for item in updated.get("scorers", [])]
+        recompute_ids = [
+            str(item.get("to", {}).get("id") or "")
+            for item in result["planned_replacements"]
+            if item.get("status") == "planned"
+        ]
+        recompute_ids = [item for item in recompute_ids if item]
+        if recompute and recompute_ids:
+            result["recompute"] = client.recompute_metrics(
+                project_id,
+                log_stream_id,
+                recompute_ids,
+                args.recompute_limit,
+            )
+    except Exception as exc:
+        result["status"] = "error"
+        result["errors"] = [str(exc)]
+        write_result(args.output, result)
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 1
+
+    write_result(args.output, result)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/galileo-platform-setup/scripts/galileo_luna_scorers.py
+++ b/skills/galileo-platform-setup/scripts/galileo_luna_scorers.py
@@ -181,6 +181,34 @@ class GalileoClient:
         )
 
 
+TARGET_DEFAULT_FIELDS = [
+    "filters",
+    "cot_enabled",
+    "num_judges",
+    "scoreable_node_types",
+    "roll_up_method",
+    "input_type",
+    "output_type",
+    "model_name",
+]
+
+
+def section_defaults(section: Any) -> dict[str, Any]:
+    if not isinstance(section, dict):
+        return {}
+    return {field: section[field] for field in TARGET_DEFAULT_FIELDS if section.get(field) is not None}
+
+
+def target_default(target: dict[str, Any] | None, field: str) -> Any:
+    if not target:
+        return None
+    for section_name in ("defaults", "latest_version", "default_version"):
+        section = target.get(section_name)
+        if isinstance(section, dict) and section.get(field) is not None:
+            return section[field]
+    return target.get(field)
+
+
 def scorer_identity(scorer: dict[str, Any]) -> dict[str, Any]:
     latest = scorer.get("latest_version") or {}
     default = scorer.get("default_version") or {}
@@ -190,6 +218,9 @@ def scorer_identity(scorer: dict[str, Any]) -> dict[str, Any]:
         "label": scorer.get("label"),
         "scorer_type": scorer.get("scorer_type"),
         "model_type": scorer.get("model_type"),
+        "defaults": section_defaults(scorer.get("defaults")),
+        "latest_version": section_defaults(latest),
+        "default_version": section_defaults(default),
         "input_type": scorer.get("input_type") or latest.get("input_type") or default.get("input_type"),
         "output_type": scorer.get("output_type") or latest.get("output_type") or default.get("output_type"),
         "default_version_id": scorer.get("default_version_id"),
@@ -242,9 +273,7 @@ def scorer_config_from_target(
     for field in optional_fields:
         value = replacement.get(field)
         if value is None:
-            value = (target or {}).get(field)
-        if value is None:
-            value = current.get(field)
+            value = target_default(target, field)
         if value is not None:
             config[field] = value
 
@@ -254,13 +283,13 @@ def scorer_config_from_target(
     model_type = replacement.get("model_type") or (target or {}).get("model_type") or "slm"
     if model_type:
         config["model_type"] = model_type
-    output_type = replacement.get("output_type") or (target or {}).get("output_type") or current.get("output_type")
+    output_type = replacement.get("output_type") or target_default(target, "output_type") or current.get("output_type")
     if output_type:
         config["output_type"] = output_type
-    input_type = replacement.get("input_type") or (target or {}).get("input_type") or current.get("input_type")
+    input_type = replacement.get("input_type") or target_default(target, "input_type") or current.get("input_type")
     if input_type:
         config["input_type"] = input_type
-    model_name = replacement.get("model_name") or (target or {}).get("model_name")
+    model_name = replacement.get("model_name") or target_default(target, "model_name")
     if model_name:
         config["model_name"] = model_name
     return config

--- a/skills/galileo-platform-setup/scripts/render_assets.py
+++ b/skills/galileo-platform-setup/scripts/render_assets.py
@@ -21,6 +21,7 @@ SKILL_NAME = "galileo-platform-setup"
 APPLY_SECTIONS = [
     "readiness",
     "object-lifecycle",
+    "luna-scorers",
     "observe-export",
     "observe-runtime",
     "protect-runtime",
@@ -36,6 +37,7 @@ APPLY_SECTIONS = [
 O11Y_ONLY_SECTIONS = [
     "readiness",
     "object-lifecycle",
+    "luna-scorers",
     "observe-runtime",
     "protect-runtime",
     "evaluate-assets",
@@ -93,6 +95,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--experiment-manifest", default="")
     parser.add_argument("--protect-stage-manifest", default="")
     parser.add_argument("--metrics", default="")
+    parser.add_argument("--luna-scorer-map", default="")
+    parser.add_argument("--luna-list-only", choices=["true", "false"], default="")
+    parser.add_argument("--luna-recompute", choices=["true", "false"], default="")
+    parser.add_argument("--luna-strict", choices=["true", "false"], default="")
+    parser.add_argument("--luna-recompute-limit", default="")
     parser.add_argument("--galileo-api-base", default="")
     parser.add_argument("--galileo-console-url", default="")
     parser.add_argument("--galileo-otel-endpoint", default="")
@@ -293,6 +300,28 @@ def merge_config(args: argparse.Namespace, spec: dict[str, Any]) -> dict[str, An
             "",
         ),
         "metrics": arg_or_spec("metrics", "galileo.metrics", ""),
+        "luna_scorer_map": arg_or_spec(
+            "luna_scorer_map",
+            "galileo.luna_scorer_map",
+            "",
+        ),
+        "luna_list_only": str(
+            args.luna_list_only or get_nested(spec, "galileo.luna_list_only", "false") or "false"
+        ).lower()
+        in {"1", "yes", "true"},
+        "luna_recompute": str(
+            args.luna_recompute or get_nested(spec, "galileo.luna_recompute", "false") or "false"
+        ).lower()
+        in {"1", "yes", "true"},
+        "luna_strict": str(
+            args.luna_strict or get_nested(spec, "galileo.luna_strict", "false") or "false"
+        ).lower()
+        in {"1", "yes", "true"},
+        "luna_recompute_limit": arg_or_spec(
+            "luna_recompute_limit",
+            "galileo.luna_recompute_limit",
+            "100",
+        ),
         "galileo_api_base": api_base,
         "galileo_console_url": console_url,
         "galileo_otel_endpoint": otel_endpoint,
@@ -536,6 +565,32 @@ cmd=(python3 "${{PROJECT_ROOT}}/skills/galileo-platform-setup/scripts/galileo_ob
     write_text(scripts_dir / "apply-object-lifecycle.sh", object_lifecycle, executable=True)
     scripts["object-lifecycle"] = "scripts/apply-object-lifecycle.sh"
 
+    luna_scorers = f"""{script_header()}
+{require_file_var("GALILEO_API_KEY_FILE", config["galileo_api_key_file"], "--galileo-api-key-file")}
+cmd=(python3 "${{PROJECT_ROOT}}/skills/galileo-platform-setup/scripts/galileo_luna_scorers.py"
+  --galileo-api-key-file "${{GALILEO_API_KEY_FILE}}"
+  --api-base {shell_quote(config["galileo_api_base"])}
+  --project-id {shell_quote(config["project_id"])}
+  --log-stream-id {shell_quote(config["log_stream_id"])}
+  --lifecycle-result "${{OUTPUT_DIR}}/lifecycle/object-lifecycle-result.json"
+  --output "${{OUTPUT_DIR}}/lifecycle/luna-scorer-settings-result.json")
+"""
+    if config["luna_scorer_map"]:
+        luna_scorers += f'cmd+=(--scorer-map {shell_quote(config["luna_scorer_map"])})\n'
+    else:
+        luna_scorers += 'cmd+=(--scorer-map "${OUTPUT_DIR}/lifecycle/luna-scorer-map.example.json")\n'
+    if config["luna_recompute"]:
+        luna_scorers += "cmd+=(--recompute)\n"
+    if config["luna_list_only"]:
+        luna_scorers += "cmd+=(--list-only)\n"
+    if config["luna_strict"]:
+        luna_scorers += "cmd+=(--strict)\n"
+    if config["luna_recompute_limit"]:
+        luna_scorers += f'cmd+=(--recompute-limit {shell_quote(config["luna_recompute_limit"])})\n'
+    luna_scorers += 'exec "${cmd[@]}"\n'
+    write_text(scripts_dir / "apply-luna-scorers.sh", luna_scorers, executable=True)
+    scripts["luna-scorers"] = "scripts/apply-luna-scorers.sh"
+
     splunk_hec = f"""{script_header()}
 {require_file_var("SPLUNK_HEC_TOKEN_FILE", config["splunk_hec_token_file"], "--splunk-hec-token-file")}
 exec bash "${{PROJECT_ROOT}}/skills/splunk-hec-service-setup/scripts/setup.sh" \\
@@ -758,6 +813,7 @@ exec bash "${{PROJECT_ROOT}}/skills/splunk-observability-native-ops/scripts/setu
   case "${section}" in
     readiness) "${SCRIPT_DIR}/apply-readiness.sh" ;;
     object-lifecycle) "${SCRIPT_DIR}/apply-object-lifecycle.sh" ;;
+    luna-scorers) "${SCRIPT_DIR}/apply-luna-scorers.sh" ;;
     observe-export) "${SCRIPT_DIR}/apply-observe-export.sh" ;;
     observe-runtime) "${SCRIPT_DIR}/apply-observe-runtime.sh" ;;
     protect-runtime) "${SCRIPT_DIR}/apply-protect-runtime.sh" ;;
@@ -1253,10 +1309,19 @@ def product_coverage_matrix(config: dict[str, Any]) -> list[dict[str, Any]]:
         },
         {
             "surface": "Evaluate metrics and scorers",
-            "lifecycle": ["enable_log_stream_metrics", "run_experiment_metrics", "custom_scorer_handoff"],
-            "coverage": "automated_built_in_metric_enablement_and_manifest_handoff",
-            "rendered_assets": ["evaluate/evaluate-assets.yaml", "lifecycle/product-coverage-matrix.json"],
-            "apply_script": "scripts/apply-object-lifecycle.sh",
+            "lifecycle": [
+                "enable_log_stream_metrics",
+                "attach_luna_slm_scorers",
+                "run_experiment_metrics",
+                "custom_scorer_handoff",
+            ],
+            "coverage": "automated_built_in_metric_enablement_luna_scorer_attach_and_manifest_handoff",
+            "rendered_assets": [
+                "evaluate/evaluate-assets.yaml",
+                "lifecycle/luna-scorer-map.example.json",
+                "lifecycle/product-coverage-matrix.json",
+            ],
+            "apply_script": "scripts/apply-luna-scorers.sh",
             "docs": "https://docs.galileo.ai/sdk-api/python/reference/log_streams",
         },
         {
@@ -1286,8 +1351,12 @@ def product_coverage_matrix(config: dict[str, Any]) -> list[dict[str, Any]]:
                 "validate_scorer_handoff",
             ],
             "coverage": "rendered_handoff_for_scorer_authoring_validation_and_settings",
-            "rendered_assets": ["evaluate/evaluate-assets.yaml", "lifecycle/product-coverage-matrix.json"],
-            "apply_script": "scripts/apply-evaluate-assets.sh",
+            "rendered_assets": [
+                "evaluate/evaluate-assets.yaml",
+                "lifecycle/luna-scorer-map.example.json",
+                "lifecycle/product-coverage-matrix.json",
+            ],
+            "apply_script": "scripts/apply-luna-scorers.sh",
             "docs": "https://docs.galileo.ai/sdk-api/python/reference/scorers",
         },
         {
@@ -1307,10 +1376,20 @@ def product_coverage_matrix(config: dict[str, Any]) -> list[dict[str, Any]]:
         },
         {
             "surface": "Luna and model/provider integrations",
-            "lifecycle": ["tenant_feature_check", "model_alias_review", "provider_integration_handoff"],
-            "coverage": "readiness_handoff_for_enterprise_features_and_model_alias_prereqs",
-            "rendered_assets": ["readiness/readiness-report.json", "evaluate/experiment-handoff.md"],
-            "apply_script": "scripts/apply-readiness.sh",
+            "lifecycle": [
+                "tenant_feature_check",
+                "model_alias_review",
+                "list_slm_scorers",
+                "attach_existing_luna_presets",
+                "provider_integration_handoff",
+            ],
+            "coverage": "automated_luna_slm_scorer_inventory_and_metric_settings_patch_plus_provider_handoff",
+            "rendered_assets": [
+                "readiness/readiness-report.json",
+                "lifecycle/luna-scorer-map.example.json",
+                "evaluate/experiment-handoff.md",
+            ],
+            "apply_script": "scripts/apply-luna-scorers.sh",
             "docs": "https://docs.galileo.ai/sdk-api/python/sdk-reference",
         },
         {
@@ -1820,9 +1899,25 @@ def render_object_lifecycle(output_dir: Path, config: dict[str, Any]) -> None:
         "scorers": {
             "custom_code": [],
             "custom_llm": [],
-            "luna": [],
+            "luna": [
+                {
+                    "from": "completeness",
+                    "to": "completeness_luna",
+                    "mode": "attach_existing_slm_preset",
+                },
+                {
+                    "from": "tool_selection_quality",
+                    "to": "tool_selection_quality_luna",
+                    "mode": "attach_existing_slm_preset",
+                },
+                {
+                    "from": "tool_error_rate",
+                    "to": "tool_error_rate_luna",
+                    "mode": "attach_existing_slm_preset",
+                },
+            ],
             "preset": [],
-            "note": "Validate and register scorers with a deliberate operator step before enabling on production log streams.",
+            "note": "Use scripts/apply-luna-scorers.sh to replace OpenAI/LLM-backed preset scorer settings with available Luna/SLM preset or custom scorer IDs.",
         },
         "annotation_templates": [],
         "feedback_templates": [],
@@ -1849,6 +1944,53 @@ def render_object_lifecycle(output_dir: Path, config: dict[str, Any]) -> None:
         },
     }
     write_json(output_dir / "lifecycle/object-lifecycle-manifest.example.json", manifest)
+    write_json(
+        output_dir / "lifecycle/luna-scorer-map.example.json",
+        {
+            "api_version": f"{SKILL_NAME}/luna-scorer-map/v1",
+            "strict": False,
+            "list_only": config["luna_list_only"],
+            "recompute": config["luna_recompute"],
+            "replacements": [
+                {"from": "correctness", "to": "correctness_luna"},
+                {"from": "completeness", "to": "completeness_luna"},
+                {"from": "instruction_adherence", "to": "instruction_adherence_luna"},
+                {"from": "tool_selection_quality", "to": "tool_selection_quality_luna"},
+                {"from": "tool_error_rate", "to": "tool_error_rate_luna"},
+                {"from": "agent_efficiency", "to": "agent_efficiency_luna"},
+            ],
+            "custom_luna_scorer_ids": [
+                {
+                    "from": "correctness",
+                    "to_id": "",
+                    "scorer_type": "luna",
+                    "model_type": "slm",
+                    "note": "Fill to_id with a registered custom Luna scorer when no built-in correctness_luna preset exists.",
+                },
+                {
+                    "from": "instruction_adherence",
+                    "to_id": "",
+                    "scorer_type": "luna",
+                    "model_type": "slm",
+                    "note": "Fill to_id with a registered custom Luna scorer when no built-in instruction_adherence_luna preset exists.",
+                },
+                {
+                    "from": "agent_efficiency",
+                    "to_id": "",
+                    "scorer_type": "luna",
+                    "model_type": "slm",
+                    "note": "Fill to_id with a registered custom Luna scorer when no built-in agent_efficiency_luna preset exists.",
+                },
+            ],
+            "notes": [
+                "The apply script preserves current scorers when a requested Luna target is unavailable.",
+                "Set list_only=true or pass --luna-list-only true to inventory current and available scorers without patching metric settings.",
+                "Set strict=true or pass --luna-strict true when partial replacement should fail.",
+                "Set remove=true on a replacement to drop a known-bad scorer when no Luna target should be enabled.",
+                "Set recompute=true or pass --luna-recompute true to request metric recomputation after a successful patch.",
+            ],
+        },
+    )
     write_json(output_dir / "lifecycle/product-coverage-matrix.json", product_coverage_matrix(config))
     write_text(
         output_dir / "lifecycle/product-coverage-matrix.md",
@@ -2514,6 +2656,7 @@ def build_apply_plan(
     targets = {
         "readiness": "galileo-platform-setup",
         "object-lifecycle": "galileo-platform-setup",
+        "luna-scorers": "galileo-platform-setup",
         "observe-export": "galileo-platform-setup",
         "observe-runtime": "galileo-platform-setup",
         "protect-runtime": "galileo-platform-setup",
@@ -2599,6 +2742,21 @@ def build_coverage_report(config: dict[str, Any]) -> dict[str, Any]:
                     "luna_studio_training_lifecycle",
                     "provider_integrations",
                     "trace_metrics_and_live_logging",
+                ],
+            },
+            "galileo_luna_scorer_settings": {
+                "status": "automated_inventory_and_metric_settings_patch",
+                "script": "scripts/galileo_luna_scorers.py",
+                "assets": [
+                    "lifecycle/luna-scorer-map.example.json",
+                    "lifecycle/luna-scorer-settings-result.json",
+                ],
+                "covers": [
+                    "list_slm_scorers",
+                    "replace_openai_llm_scorers_with_luna_slm_targets",
+                    "preserve_unmapped_scorers",
+                    "optional_recompute_metrics",
+                    "custom_luna_scorer_id_mapping",
                 ],
             },
             "galileo_full_feature_coverage_matrix": {
@@ -2703,7 +2861,7 @@ def render_handoff(output_dir: Path, config: dict[str, Any], scripts: dict[str, 
 
 
 def maybe_copy_runtime_scripts(output_dir: Path) -> None:
-    for name in ("galileo_to_splunk_hec.py", "galileo_object_lifecycle.py"):
+    for name in ("galileo_to_splunk_hec.py", "galileo_object_lifecycle.py", "galileo_luna_scorers.py"):
         source = Path(__file__).with_name(name)
         if not source.is_file():
             continue

--- a/skills/galileo-platform-setup/scripts/setup.sh
+++ b/skills/galileo-platform-setup/scripts/setup.sh
@@ -11,7 +11,7 @@ DEFAULT_OUTPUT_DIR="${PROJECT_ROOT}/galileo-platform-rendered"
 RENDERER="${SCRIPT_DIR}/render_assets.py"
 VALIDATE_SCRIPT="${SCRIPT_DIR}/validate.sh"
 
-APPLY_SECTIONS_DEFAULT="readiness,object-lifecycle,observe-export,observe-runtime,protect-runtime,evaluate-assets,multimodal-assets,observability-controls,splunk-hec,splunk-otlp,otel-collector,dashboards,detectors"
+APPLY_SECTIONS_DEFAULT="readiness,object-lifecycle,luna-scorers,observe-export,observe-runtime,protect-runtime,evaluate-assets,multimodal-assets,observability-controls,splunk-hec,splunk-otlp,otel-collector,dashboards,detectors"
 
 usage() {
     cat <<'EOF'
@@ -37,6 +37,8 @@ Apply sections:
   readiness                     Render/optionally probe Galileo endpoint and readiness checklist
   object-lifecycle              Create/validate Galileo projects, log streams, datasets, prompts,
                                 experiments, metrics, Protect stages, and Agent Control targets
+  luna-scorers                  Attach available Luna/SLM preset or custom scorers to log stream
+                                metric settings and optionally recompute metrics
   observe-export                Run the Galileo export_records to Splunk HEC bridge
   observe-runtime               Copy or point to Observe OpenTelemetry/OpenInference snippets
   protect-runtime               Copy or point to Protect invoke runtime snippets
@@ -62,6 +64,11 @@ Configuration:
   --experiment-manifest PATH    Experiment manifest to create or run
   --protect-stage-manifest PATH Protect stage manifest to create or validate
   --metrics CSV                 Built-in metric names to enable on the log stream or experiments
+  --luna-scorer-map PATH        JSON scorer replacement map for Luna/SLM metric settings
+  --luna-list-only true|false   Inventory current and available scorers without patching
+  --luna-recompute true|false   Request metric recomputation after Luna scorer attach
+  --luna-strict true|false      Fail if any mapped Luna scorer target is unavailable
+  --luna-recompute-limit NUM    Log-record recompute batch limit (default: 100)
   --galileo-api-base URL        Galileo REST API base (default: https://api.galileo.ai)
   --galileo-console-url URL     Galileo console URL; used to derive API base when supplied
   --galileo-otel-endpoint URL   Galileo OTLP traces endpoint
@@ -164,7 +171,7 @@ while [[ $# -gt 0 ]]; do
         --allow-raw-media-in-splunk) RENDER_ARGS+=("$1"); shift ;;
         --spec) require_value "$1" "$#"; SPEC="$2"; shift 2 ;;
         --output-dir) require_value "$1" "$#"; OUTPUT_DIR="$2"; shift 2 ;;
-        --project-id|--project-name|--log-stream-id|--log-stream|--lifecycle-manifest|--dataset-dir|--prompt-manifest|--experiment-manifest|--protect-stage-manifest|--metrics|--galileo-api-base|--galileo-console-url|--galileo-otel-endpoint|--experiment-id|--metrics-testing-id|--multimodal-enabled|--multimodal-input-modalities|--multimodal-output-modalities|--multimodal-capture-methods|--multimodal-quality-metrics|--multimodal-asset-policy|--export-format|--redact|--root-type|--since|--until|--cursor-file|--splunk-platform|--splunk-hec-url|--splunk-index|--splunk-source|--splunk-sourcetype|--splunk-host|--hec-token-name|--hec-allowed-indexes|--realm|--service-name|--deployment-environment|--otlp-receiver-host|--otlp-grpc-port|--otlp-http-port|--collector-cluster-name|--kube-namespace|--kube-workload|--runtime-target-dir|--galileo-api-key-file|--splunk-hec-token-file|--o11y-token-file)
+        --project-id|--project-name|--log-stream-id|--log-stream|--lifecycle-manifest|--dataset-dir|--prompt-manifest|--experiment-manifest|--protect-stage-manifest|--metrics|--luna-scorer-map|--luna-list-only|--luna-recompute|--luna-strict|--luna-recompute-limit|--galileo-api-base|--galileo-console-url|--galileo-otel-endpoint|--experiment-id|--metrics-testing-id|--multimodal-enabled|--multimodal-input-modalities|--multimodal-output-modalities|--multimodal-capture-methods|--multimodal-quality-metrics|--multimodal-asset-policy|--export-format|--redact|--root-type|--since|--until|--cursor-file|--splunk-platform|--splunk-hec-url|--splunk-index|--splunk-source|--splunk-sourcetype|--splunk-host|--hec-token-name|--hec-allowed-indexes|--realm|--service-name|--deployment-environment|--otlp-receiver-host|--otlp-grpc-port|--otlp-http-port|--collector-cluster-name|--kube-namespace|--kube-workload|--runtime-target-dir|--galileo-api-key-file|--splunk-hec-token-file|--o11y-token-file)
             require_value "$1" "$#"
             RENDER_ARGS+=("$1" "$2")
             shift 2
@@ -212,6 +219,7 @@ apply_section() {
     case "${section}" in
         readiness) script="apply-readiness.sh" ;;
         object-lifecycle) script="apply-object-lifecycle.sh" ;;
+        luna-scorers) script="apply-luna-scorers.sh" ;;
         observe-export) script="apply-observe-export.sh" ;;
         observe-runtime) script="apply-observe-runtime.sh" ;;
         protect-runtime) script="apply-protect-runtime.sh" ;;
@@ -255,7 +263,7 @@ if [[ "${MODE_APPLY}" == "true" ]]; then
         sections="${APPLY_SECTIONS_DEFAULT}"
     fi
     if [[ "${O11Y_ONLY}" == "true" && ( -z "${APPLY_SECTIONS}" || "${APPLY_SECTIONS}" == "all" ) ]]; then
-        sections="readiness,object-lifecycle,observe-runtime,protect-runtime,evaluate-assets,multimodal-assets,observability-controls,otel-collector,dashboards,detectors"
+        sections="readiness,object-lifecycle,luna-scorers,observe-runtime,protect-runtime,evaluate-assets,multimodal-assets,observability-controls,otel-collector,dashboards,detectors"
     fi
     IFS=',' read -ra section_array <<< "${sections}"
     for section in "${section_array[@]}"; do

--- a/skills/galileo-platform-setup/scripts/validate.sh
+++ b/skills/galileo-platform-setup/scripts/validate.sh
@@ -55,6 +55,7 @@ check_file "${OUTPUT_DIR}/handoff.md"
 check_file "${OUTPUT_DIR}/readiness/readiness-report.json"
 check_exec "${OUTPUT_DIR}/readiness/healthcheck.sh"
 check_file "${OUTPUT_DIR}/lifecycle/object-lifecycle-manifest.example.json"
+check_file "${OUTPUT_DIR}/lifecycle/luna-scorer-map.example.json"
 check_file "${OUTPUT_DIR}/lifecycle/product-coverage-matrix.json"
 check_file "${OUTPUT_DIR}/lifecycle/product-coverage-matrix.md"
 check_file "${OUTPUT_DIR}/runtime/python-opentelemetry-env.sh"
@@ -72,6 +73,7 @@ check_file "${OUTPUT_DIR}/splunk-platform/multimodal-search-examples.spl"
 check_file "${OUTPUT_DIR}/otel/collector-galileo-fanout.yaml"
 check_exec "${OUTPUT_DIR}/scripts/apply-readiness.sh"
 check_exec "${OUTPUT_DIR}/scripts/apply-object-lifecycle.sh"
+check_exec "${OUTPUT_DIR}/scripts/apply-luna-scorers.sh"
 check_exec "${OUTPUT_DIR}/scripts/apply-observe-export.sh"
 check_exec "${OUTPUT_DIR}/scripts/apply-observe-runtime.sh"
 check_exec "${OUTPUT_DIR}/scripts/apply-protect-runtime.sh"
@@ -95,6 +97,7 @@ sections = {item["name"]: item for item in plan["sections"]}
 required = {
     "readiness": "galileo-platform-setup",
     "object-lifecycle": "galileo-platform-setup",
+    "luna-scorers": "galileo-platform-setup",
     "observe-export": "galileo-platform-setup",
     "observe-runtime": "galileo-platform-setup",
     "protect-runtime": "galileo-platform-setup",
@@ -120,6 +123,9 @@ if coverage.get("secret_values_rendered") is not False:
 lifecycle = coverage.get("coverage", {}).get("galileo_object_lifecycle", {})
 if lifecycle.get("status") != "automated_create_or_get":
     raise SystemExit("coverage report must include automated Galileo object lifecycle coverage")
+luna = coverage.get("coverage", {}).get("galileo_luna_scorer_settings", {})
+if luna.get("status") != "automated_inventory_and_metric_settings_patch":
+    raise SystemExit("coverage report must include automated Galileo Luna scorer settings coverage")
 controls = coverage.get("coverage", {}).get("galileo_agent_observability_controls", {})
 if controls.get("status") != "rendered_handoff":
     raise SystemExit("coverage report must include Galileo Agent Observability Controls handoff coverage")

--- a/skills/galileo-platform-setup/template.example
+++ b/skills/galileo-platform-setup/template.example
@@ -16,6 +16,11 @@ galileo:
   experiment_manifest: ""
   protect_stage_manifest: ""
   metrics: "correctness,completeness"
+  luna_scorer_map: "./galileo-platform-rendered/lifecycle/luna-scorer-map.example.json"
+  luna_list_only: true
+  luna_recompute: false
+  luna_strict: false
+  luna_recompute_limit: "100"
   experiment_id: ""
   metrics_testing_id: ""
 

--- a/tests/test_galileo_platform_setup.py
+++ b/tests/test_galileo_platform_setup.py
@@ -19,6 +19,7 @@ VALIDATE = SKILL_DIR / "scripts/validate.sh"
 RENDER = SKILL_DIR / "scripts/render_assets.py"
 BRIDGE = SKILL_DIR / "scripts/galileo_to_splunk_hec.py"
 LIFECYCLE = SKILL_DIR / "scripts/galileo_object_lifecycle.py"
+LUNA = SKILL_DIR / "scripts/galileo_luna_scorers.py"
 
 
 def run_cmd(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -56,9 +57,11 @@ def test_setup_help_lists_apply_sections() -> None:
     combined = result.stdout + result.stderr
 
     assert "--o11y-only" in combined
+    assert "--luna-list-only" in combined
     for section in [
         "readiness",
         "object-lifecycle",
+        "luna-scorers",
         "observe-export",
         "observe-runtime",
         "protect-runtime",
@@ -91,6 +94,7 @@ def test_default_render_emits_plan_coverage_and_handoff_scripts(tmp_path: Path) 
     assert (output_dir / "handoff.md").is_file()
     assert (output_dir / "readiness/readiness-report.json").is_file()
     assert (output_dir / "lifecycle/object-lifecycle-manifest.example.json").is_file()
+    assert (output_dir / "lifecycle/luna-scorer-map.example.json").is_file()
     assert (output_dir / "lifecycle/product-coverage-matrix.json").is_file()
     assert (output_dir / "lifecycle/product-coverage-matrix.md").is_file()
     assert (output_dir / "runtime/python-opentelemetry-env.sh").is_file()
@@ -156,6 +160,7 @@ def test_default_render_emits_plan_coverage_and_handoff_scripts(tmp_path: Path) 
     for script in [
         "apply-readiness.sh",
         "apply-object-lifecycle.sh",
+        "apply-luna-scorers.sh",
         "apply-observe-export.sh",
         "apply-observe-runtime.sh",
         "apply-protect-runtime.sh",
@@ -259,6 +264,7 @@ def test_o11y_only_otel_collector_handoff_omits_platform_hec(tmp_path: Path) -> 
     assert plan["selected_sections"] == [
         "readiness",
         "object-lifecycle",
+        "luna-scorers",
         "observe-runtime",
         "protect-runtime",
         "evaluate-assets",
@@ -288,6 +294,7 @@ def test_o11y_only_default_apply_dry_run_selects_cloud_sections(tmp_path: Path) 
     assert payload["selected_sections"] == [
         "readiness",
         "object-lifecycle",
+        "luna-scorers",
         "observe-runtime",
         "protect-runtime",
         "evaluate-assets",
@@ -626,6 +633,97 @@ def test_object_lifecycle_dry_run_covers_core_galileo_objects(tmp_path: Path) ->
     assert output.is_file()
 
 
+def test_luna_scorer_script_dry_run_builds_partial_replacement_plan(tmp_path: Path) -> None:
+    token_file = tmp_path / "galileo.token"
+    token_file.write_text("unused", encoding="utf-8")
+    output = tmp_path / "luna-result.json"
+    module = importlib.util.module_from_spec(
+        importlib.util.spec_from_file_location("galileo_luna_scorers", LUNA)
+    )
+    assert module.__spec__ and module.__spec__.loader
+    module.__spec__.loader.exec_module(module)
+
+    settings = {
+        "scorers": [
+            {
+                "id": "00000000-0000-4000-8000-000000000001",
+                "name": "completeness",
+                "scorer_type": "preset",
+                "model_type": "llm",
+                "input_type": "llm_spans",
+                "output_type": "percentage",
+                "scoreable_node_types": ["llm", "chat"],
+            },
+            {
+                "id": "00000000-0000-4000-8000-000000000002",
+                "name": "correctness",
+                "scorer_type": "preset",
+                "model_type": "llm",
+                "input_type": "llm_spans",
+                "output_type": "boolean_multilabel",
+                "scoreable_node_types": ["llm", "chat"],
+            },
+            {
+                "id": "00000000-0000-4000-8000-000000000005",
+                "name": "agent_efficiency",
+                "scorer_type": "preset",
+                "model_type": "llm",
+                "input_type": "sessions_normalized",
+                "output_type": "boolean_multilabel",
+                "scoreable_node_types": ["session"],
+            },
+        ],
+        "segment_filters": None,
+    }
+    targets = {
+        "completeness_luna": {
+            "id": "00000000-0000-4000-8000-000000000003",
+            "name": "completeness_luna",
+            "scorer_type": "preset",
+            "model_type": "slm",
+            "output_type": "percentage",
+        }
+    }
+
+    plan = module.build_metric_settings_plan(
+        settings,
+        module.normalize_replacements(
+            {
+                "strict": "false",
+                "replacements": module.DEFAULT_REPLACEMENTS
+                + [{"from": "agent_efficiency", "remove": True}],
+                "custom_luna_scorer_ids": [
+                    {
+                        "from": "correctness",
+                        "to_id": "00000000-0000-4000-8000-000000000004",
+                        "scorer_type": "luna",
+                        "model_type": "slm",
+                    },
+                    {"from": "agent_efficiency", "to_id": ""},
+                ],
+            }
+        ),
+        targets,
+        strict=False,
+    )
+
+    assert plan["errors"] == []
+    assert plan["applied"][0]["from"]["name"] == "completeness"
+    assert plan["applied"][0]["to"]["name"] == "completeness_luna"
+    assert plan["applied"][1]["from"]["name"] == "correctness"
+    assert plan["applied"][1]["to"]["id"].endswith("0004")
+    assert plan["unavailable"] == []
+    assert plan["patch_body"]["scorers"][0]["id"].endswith("0003")
+    assert plan["patch_body"]["scorers"][0]["model_type"] == "slm"
+    assert plan["patch_body"]["scorers"][0]["input_type"] == "llm_spans"
+    assert plan["patch_body"]["scorers"][1]["id"].endswith("0004")
+    assert plan["patch_body"]["scorers"][1]["scorer_type"] == "luna"
+    assert [item["status"] for item in plan["applied"]] == ["planned", "planned", "removed"]
+    assert all(not item["id"].endswith("0005") for item in plan["patch_body"]["scorers"])
+    module.write_result(str(output), {"status": "planned"})
+    assert json.loads(output.read_text(encoding="utf-8"))["status"] == "planned"
+
+
 def test_repo_has_no_legacy_galileo_skill_references() -> None:
     legacy = "splunk-" + "galileo-integration"
     result = run_cmd("git", "grep", "-n", legacy, "--", ".", check=False)
@@ -633,4 +731,4 @@ def test_repo_has_no_legacy_galileo_skill_references() -> None:
 
 
 def test_python_scripts_compile() -> None:
-    run_cmd(sys.executable, "-m", "py_compile", str(RENDER), str(BRIDGE), str(LIFECYCLE))
+    run_cmd(sys.executable, "-m", "py_compile", str(RENDER), str(BRIDGE), str(LIFECYCLE), str(LUNA))

--- a/tests/test_galileo_platform_setup.py
+++ b/tests/test_galileo_platform_setup.py
@@ -652,6 +652,8 @@ def test_luna_scorer_script_dry_run_builds_partial_replacement_plan(tmp_path: Pa
                 "model_type": "llm",
                 "input_type": "llm_spans",
                 "output_type": "percentage",
+                "filters": [{"name": "old_filter"}],
+                "num_judges": 3,
                 "scoreable_node_types": ["llm", "chat"],
             },
             {
@@ -677,13 +679,18 @@ def test_luna_scorer_script_dry_run_builds_partial_replacement_plan(tmp_path: Pa
     }
     targets = {
         "completeness_luna": {
-            "id": "00000000-0000-4000-8000-000000000003",
-            "name": "completeness_luna",
-            "scorer_type": "preset",
-            "model_type": "slm",
-            "output_type": "percentage",
+                "id": "00000000-0000-4000-8000-000000000003",
+                "name": "completeness_luna",
+                "scorer_type": "preset",
+                "model_type": "slm",
+                "output_type": "percentage",
+                "defaults": {
+                    "filters": [{"name": "luna_filter"}],
+                    "num_judges": 1,
+                    "scoreable_node_types": ["session"],
+                },
+            }
         }
-    }
 
     plan = module.build_metric_settings_plan(
         settings,
@@ -716,8 +723,12 @@ def test_luna_scorer_script_dry_run_builds_partial_replacement_plan(tmp_path: Pa
     assert plan["patch_body"]["scorers"][0]["id"].endswith("0003")
     assert plan["patch_body"]["scorers"][0]["model_type"] == "slm"
     assert plan["patch_body"]["scorers"][0]["input_type"] == "llm_spans"
+    assert plan["patch_body"]["scorers"][0]["filters"] == [{"name": "luna_filter"}]
+    assert plan["patch_body"]["scorers"][0]["num_judges"] == 1
+    assert plan["patch_body"]["scorers"][0]["scoreable_node_types"] == ["session"]
     assert plan["patch_body"]["scorers"][1]["id"].endswith("0004")
     assert plan["patch_body"]["scorers"][1]["scorer_type"] == "luna"
+    assert "scoreable_node_types" not in plan["patch_body"]["scorers"][1]
     assert [item["status"] for item in plan["applied"]] == ["planned", "planned", "removed"]
     assert all(not item["id"].endswith("0005") for item in plan["patch_body"]["scorers"])
     module.write_result(str(output), {"status": "planned"})


### PR DESCRIPTION
## Summary

Adds Galileo Luna scorer configuration support to the Galileo platform setup skill.

- Adds a file-secret based `galileo_luna_scorers.py` helper for listing, replacing, and recomputing Galileo metric settings with Luna/SLM scorers.
- Renders an `apply-luna-scorers.sh` section, scorer-map example JSON, template fields, validation checks, and coverage metadata.
- Documents the Codex-focused Luna scorer workflow and adds focused tests for rendering, section selection, and scorer replacement planning.

## Why

The Codex log stream was showing metric errors from non-Luna/custom scorer configuration. This makes the skill reusable for other people by letting rendered Galileo setup bundles apply Luna scorer metric settings without exposing API keys.

## Validation

- `python3 -m py_compile skills/galileo-platform-setup/scripts/render_assets.py skills/galileo-platform-setup/scripts/galileo_luna_scorers.py skills/galileo-platform-setup/scripts/galileo_object_lifecycle.py skills/galileo-platform-setup/scripts/galileo_to_splunk_hec.py`
- `pytest -q tests/test_galileo_platform_setup.py` -> `18 passed`