### PR TITLE
fix: align marketplace skill contracts

### DIFF
--- a/skills/cisco-collaboration-setup/SKILL.md
+++ b/skills/cisco-collaboration-setup/SKILL.md
@@ -34,6 +34,33 @@ Do not use this skill for Webex REST collection itself; hand that work to
 `cisco-webex-setup`. Use `cisco-thousandeyes-setup` for ThousandEyes data and
 `cisco-product-setup` when the Cisco product is not yet known.
 
+## Workflow Overview
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│  1. REVIEW INTAKE                                               │
+│  Confirm product routes, privacy choices, and local evidence    │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  2. RENDER OFFLINE                                              │
+│  Build classifier, readiness, evidence, gap, and handoff assets │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  3. VALIDATE                                                    │
+│  Re-read trusted evidence and verify the private packet         │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  4. HAND OFF                                                    │
+│  Operators review unresolved gaps before any child workflow     │
+└─────────────────────────────────────────────────────────────────┘
+```
+
 ## Safety Contract
 
 - Rendering is the only mode and is the default. There is no apply, install,
@@ -77,7 +104,7 @@ Do not use this skill for Webex REST collection itself; hand that work to
   install commands; require exact version, tier, entitlement, and package
   metadata evidence before recording a selection.
 
-## Render and Validate
+## Commands: Render and Validate
 
 Render the example spec offline:
 

--- a/skills/cisco-collaboration-setup/scripts/render_assets.py
+++ b/skills/cisco-collaboration-setup/scripts/render_assets.py
@@ -3387,7 +3387,9 @@ def validate_command_plan(plan: dict[str, Any], out: Path) -> None:
             for arg in command:
                 flag = arg.split("=", 1)[0]
                 if flag in FORBIDDEN_ARG_FLAGS or SECRET_KEY_RE.search(flag):
-                    raise SpecError(f"handoff plan contains a forbidden mutation or secret argument: {flag}")
+                    raise SpecError(
+                        f"handoff plan argument is outside the render-only allowlist: {flag}"
+                    )
             if command[0] != "bash" or len(command) < 3:
                 raise SpecError("delegated commands must invoke a reviewed repo-local Bash child")
             script = command[1]

--- a/skills/splunk-cim-data-model/SKILL.md
+++ b/skills/splunk-cim-data-model/SKILL.md
@@ -15,6 +15,41 @@ metadata:
 > `splunk-cim-data-model` is deprecated and replaced by
 > [`splunk-cim-data-model-setup`](../splunk-cim-data-model-setup/SKILL.md). Use the canonical skill for all work.
 
+## Prerequisites
+
+| Requirement | Purpose | Verify |
+|---|---|---|
+| Bash and Python 3 | Display the help-only compatibility handoff | `bash --version && python3 --version` |
+| Canonical replacement | Perform supported CIM data-model work | `test -f skills/splunk-cim-data-model-setup/SKILL.md` |
+
+## When to Activate
+
+- An existing caller supplies the exact legacy name `splunk-cim-data-model`.
+- The caller needs the canonical replacement name before taking any action.
+
+Do not activate this alias for setup, rendering, validation, or live operations.
+
+## Workflow Overview
+
+```text
+┌──────────────────────────┐
+│ Compatibility invocation │
+└────────────┬─────────────┘
+             │
+     ┌───────┴────────┐
+     ▼                ▼
+┌────────────────┐  ┌────────────────────┐
+│ Exactly one    │  │ Anything else,     │
+│ --help or -h   │  │ including no args  │
+└───────┬────────┘  └─────────┬──────────┘
+        ▼                     ▼
+┌────────────────────┐  ┌────────────────────┐
+│ Show deprecation   │  │ Exit 2 before      │
+│ and canonical      │  │ rendering, network │
+│ handoff            │  │ access, or mutation│
+└────────────────────┘  └────────────────────┘
+```
+
 ## Fail-Closed Compatibility Contract
 
 This directory preserves only exact-name discovery and an actionable handoff. No legacy
@@ -28,7 +63,7 @@ Legacy reference and intake-template copies were removed so this alias cannot be
 for an independently maintained workflow. Do not reconstruct or execute an old rendered
 bundle. Read the canonical skill and collect inputs using its current contract.
 
-## Safe Compatibility Checks
+## Commands
 
 ```bash
 bash skills/splunk-cim-data-model/scripts/setup.sh --help
@@ -46,3 +81,10 @@ bash skills/splunk-cim-data-model-setup/scripts/validate.sh --help
 Any existing automation that supplies operational legacy flags must stop and be migrated
 to the canonical interface after reviewing its apply and acceptance gates. Do not infer a
 flag translation.
+
+## Troubleshooting
+
+| Failure | Meaning | Resolution |
+|---|---|---|
+| Exit status 2 | An operational legacy argument was refused | Read `splunk-cim-data-model-setup` and migrate explicitly |
+| Canonical skill missing | The checkout is incomplete or stale | Refresh the canonical skill source before continuing |

--- a/skills/splunk-dashboard-studio/SKILL.md
+++ b/skills/splunk-dashboard-studio/SKILL.md
@@ -15,6 +15,41 @@ metadata:
 > `splunk-dashboard-studio` is deprecated and replaced by
 > [`splunk-dashboard-studio-setup`](../splunk-dashboard-studio-setup/SKILL.md). Use the canonical skill for all work.
 
+## Prerequisites
+
+| Requirement | Purpose | Verify |
+|---|---|---|
+| Bash and Python 3 | Display the help-only compatibility handoff | `bash --version && python3 --version` |
+| Canonical replacement | Perform supported Dashboard Studio work | `test -f skills/splunk-dashboard-studio-setup/SKILL.md` |
+
+## When to Activate
+
+- An existing caller supplies the exact legacy name `splunk-dashboard-studio`.
+- The caller needs the canonical replacement name before taking any action.
+
+Do not activate this alias for setup, rendering, validation, or live operations.
+
+## Workflow Overview
+
+```text
+┌──────────────────────────┐
+│ Compatibility invocation │
+└────────────┬─────────────┘
+             │
+     ┌───────┴────────┐
+     ▼                ▼
+┌────────────────┐  ┌────────────────────┐
+│ Exactly one    │  │ Anything else,     │
+│ --help or -h   │  │ including no args  │
+└───────┬────────┘  └─────────┬──────────┘
+        ▼                     ▼
+┌────────────────────┐  ┌────────────────────┐
+│ Show deprecation   │  │ Exit 2 before      │
+│ and canonical      │  │ rendering, network │
+│ handoff            │  │ access, or mutation│
+└────────────────────┘  └────────────────────┘
+```
+
 ## Fail-Closed Compatibility Contract
 
 This directory preserves only exact-name discovery and an actionable handoff. No legacy
@@ -28,7 +63,7 @@ Legacy reference and intake-template copies were removed so this alias cannot be
 for an independently maintained workflow. Do not reconstruct or execute an old rendered
 bundle. Read the canonical skill and collect inputs using its current contract.
 
-## Safe Compatibility Checks
+## Commands
 
 ```bash
 bash skills/splunk-dashboard-studio/scripts/setup.sh --help
@@ -46,3 +81,10 @@ bash skills/splunk-dashboard-studio-setup/scripts/validate.sh --help
 Any existing automation that supplies operational legacy flags must stop and be migrated
 to the canonical interface after reviewing its apply and acceptance gates. Do not infer a
 flag translation.
+
+## Troubleshooting
+
+| Failure | Meaning | Resolution |
+|---|---|---|
+| Exit status 2 | An operational legacy argument was refused | Read `splunk-dashboard-studio-setup` and migrate explicitly |
+| Canonical skill missing | The checkout is incomplete or stale | Refresh the canonical skill source before continuing |

--- a/skills/splunk-ddaa-archive/SKILL.md
+++ b/skills/splunk-ddaa-archive/SKILL.md
@@ -15,6 +15,41 @@ metadata:
 > `splunk-ddaa-archive` is deprecated and replaced by
 > [`splunk-ddaa-archive-setup`](../splunk-ddaa-archive-setup/SKILL.md). Use the canonical skill for all work.
 
+## Prerequisites
+
+| Requirement | Purpose | Verify |
+|---|---|---|
+| Bash and Python 3 | Display the help-only compatibility handoff | `bash --version && python3 --version` |
+| Canonical replacement | Perform supported DDAA archive work | `test -f skills/splunk-ddaa-archive-setup/SKILL.md` |
+
+## When to Activate
+
+- An existing caller supplies the exact legacy name `splunk-ddaa-archive`.
+- The caller needs the canonical replacement name before taking any action.
+
+Do not activate this alias for setup, rendering, validation, or live operations.
+
+## Workflow Overview
+
+```text
+┌──────────────────────────┐
+│ Compatibility invocation │
+└────────────┬─────────────┘
+             │
+     ┌───────┴────────┐
+     ▼                ▼
+┌────────────────┐  ┌────────────────────┐
+│ Exactly one    │  │ Anything else,     │
+│ --help or -h   │  │ including no args  │
+└───────┬────────┘  └─────────┬──────────┘
+        ▼                     ▼
+┌────────────────────┐  ┌────────────────────┐
+│ Show deprecation   │  │ Exit 2 before      │
+│ and canonical      │  │ rendering, network │
+│ handoff            │  │ access, or mutation│
+└────────────────────┘  └────────────────────┘
+```
+
 ## Fail-Closed Compatibility Contract
 
 This directory preserves only exact-name discovery and an actionable handoff. No legacy
@@ -28,7 +63,7 @@ Legacy reference and intake-template copies were removed so this alias cannot be
 for an independently maintained workflow. Do not reconstruct or execute an old rendered
 bundle. Read the canonical skill and collect inputs using its current contract.
 
-## Safe Compatibility Checks
+## Commands
 
 ```bash
 bash skills/splunk-ddaa-archive/scripts/setup.sh --help
@@ -46,3 +81,10 @@ bash skills/splunk-ddaa-archive-setup/scripts/validate.sh --help
 Any existing automation that supplies operational legacy flags must stop and be migrated
 to the canonical interface after reviewing its apply and acceptance gates. Do not infer a
 flag translation.
+
+## Troubleshooting
+
+| Failure | Meaning | Resolution |
+|---|---|---|
+| Exit status 2 | An operational legacy argument was refused | Read `splunk-ddaa-archive-setup` and migrate explicitly |
+| Canonical skill missing | The checkout is incomplete or stale | Refresh the canonical skill source before continuing |

--- a/skills/splunk-ingest-actions/SKILL.md
+++ b/skills/splunk-ingest-actions/SKILL.md
@@ -15,6 +15,41 @@ metadata:
 > `splunk-ingest-actions` is deprecated and replaced by
 > [`splunk-ingest-actions-setup`](../splunk-ingest-actions-setup/SKILL.md). Use the canonical skill for all work.
 
+## Prerequisites
+
+| Requirement | Purpose | Verify |
+|---|---|---|
+| Bash and Python 3 | Display the help-only compatibility handoff | `bash --version && python3 --version` |
+| Canonical replacement | Perform supported Ingest Actions work | `test -f skills/splunk-ingest-actions-setup/SKILL.md` |
+
+## When to Activate
+
+- An existing caller supplies the exact legacy name `splunk-ingest-actions`.
+- The caller needs the canonical replacement name before taking any action.
+
+Do not activate this alias for setup, rendering, validation, or live operations.
+
+## Workflow Overview
+
+```text
+┌──────────────────────────┐
+│ Compatibility invocation │
+└────────────┬─────────────┘
+             │
+     ┌───────┴────────┐
+     ▼                ▼
+┌────────────────┐  ┌────────────────────┐
+│ Exactly one    │  │ Anything else,     │
+│ --help or -h   │  │ including no args  │
+└───────┬────────┘  └─────────┬──────────┘
+        ▼                     ▼
+┌────────────────────┐  ┌────────────────────┐
+│ Show deprecation   │  │ Exit 2 before      │
+│ and canonical      │  │ rendering, network │
+│ handoff            │  │ access, or mutation│
+└────────────────────┘  └────────────────────┘
+```
+
 ## Fail-Closed Compatibility Contract
 
 This directory preserves only exact-name discovery and an actionable handoff. No legacy
@@ -28,7 +63,7 @@ Legacy reference and intake-template copies were removed so this alias cannot be
 for an independently maintained workflow. Do not reconstruct or execute an old rendered
 bundle. Read the canonical skill and collect inputs using its current contract.
 
-## Safe Compatibility Checks
+## Commands
 
 ```bash
 bash skills/splunk-ingest-actions/scripts/setup.sh --help
@@ -46,3 +81,10 @@ bash skills/splunk-ingest-actions-setup/scripts/validate.sh --help
 Any existing automation that supplies operational legacy flags must stop and be migrated
 to the canonical interface after reviewing its apply and acceptance gates. Do not infer a
 flag translation.
+
+## Troubleshooting
+
+| Failure | Meaning | Resolution |
+|---|---|---|
+| Exit status 2 | An operational legacy argument was refused | Read `splunk-ingest-actions-setup` and migrate explicitly |
+| Canonical skill missing | The checkout is incomplete or stale | Refresh the canonical skill source before continuing |

--- a/skills/splunk-knowledge-objects/SKILL.md
+++ b/skills/splunk-knowledge-objects/SKILL.md
@@ -15,6 +15,41 @@ metadata:
 > `splunk-knowledge-objects` is deprecated and replaced by
 > [`splunk-knowledge-objects-setup`](../splunk-knowledge-objects-setup/SKILL.md). Use the canonical skill for all work.
 
+## Prerequisites
+
+| Requirement | Purpose | Verify |
+|---|---|---|
+| Bash and Python 3 | Display the help-only compatibility handoff | `bash --version && python3 --version` |
+| Canonical replacement | Perform supported knowledge-object work | `test -f skills/splunk-knowledge-objects-setup/SKILL.md` |
+
+## When to Activate
+
+- An existing caller supplies the exact legacy name `splunk-knowledge-objects`.
+- The caller needs the canonical replacement name before taking any action.
+
+Do not activate this alias for setup, rendering, validation, or live operations.
+
+## Workflow Overview
+
+```text
+┌──────────────────────────┐
+│ Compatibility invocation │
+└────────────┬─────────────┘
+             │
+     ┌───────┴────────┐
+     ▼                ▼
+┌────────────────┐  ┌────────────────────┐
+│ Exactly one    │  │ Anything else,     │
+│ --help or -h   │  │ including no args  │
+└───────┬────────┘  └─────────┬──────────┘
+        ▼                     ▼
+┌────────────────────┐  ┌────────────────────┐
+│ Show deprecation   │  │ Exit 2 before      │
+│ and canonical      │  │ rendering, network │
+│ handoff            │  │ access, or mutation│
+└────────────────────┘  └────────────────────┘
+```
+
 ## Fail-Closed Compatibility Contract
 
 This directory preserves only exact-name discovery and an actionable handoff. No legacy
@@ -28,7 +63,7 @@ Legacy reference and intake-template copies were removed so this alias cannot be
 for an independently maintained workflow. Do not reconstruct or execute an old rendered
 bundle. Read the canonical skill and collect inputs using its current contract.
 
-## Safe Compatibility Checks
+## Commands
 
 ```bash
 bash skills/splunk-knowledge-objects/scripts/setup.sh --help
@@ -46,3 +81,10 @@ bash skills/splunk-knowledge-objects-setup/scripts/validate.sh --help
 Any existing automation that supplies operational legacy flags must stop and be migrated
 to the canonical interface after reviewing its apply and acceptance gates. Do not infer a
 flag translation.
+
+## Troubleshooting
+
+| Failure | Meaning | Resolution |
+|---|---|---|
+| Exit status 2 | An operational legacy argument was refused | Read `splunk-knowledge-objects-setup` and migrate explicitly |
+| Canonical skill missing | The checkout is incomplete or stale | Refresh the canonical skill source before continuing |

--- a/skills/splunk-kvstore-admin/SKILL.md
+++ b/skills/splunk-kvstore-admin/SKILL.md
@@ -15,6 +15,41 @@ metadata:
 > `splunk-kvstore-admin` is deprecated and replaced by
 > [`splunk-kvstore-admin-setup`](../splunk-kvstore-admin-setup/SKILL.md). Use the canonical skill for all work.
 
+## Prerequisites
+
+| Requirement | Purpose | Verify |
+|---|---|---|
+| Bash and Python 3 | Display the help-only compatibility handoff | `bash --version && python3 --version` |
+| Canonical replacement | Perform supported KV Store work | `test -f skills/splunk-kvstore-admin-setup/SKILL.md` |
+
+## When to Activate
+
+- An existing caller supplies the exact legacy name `splunk-kvstore-admin`.
+- The caller needs the canonical replacement name before taking any action.
+
+Do not activate this alias for setup, rendering, validation, or live operations.
+
+## Workflow Overview
+
+```text
+┌──────────────────────────┐
+│ Compatibility invocation │
+└────────────┬─────────────┘
+             │
+     ┌───────┴────────┐
+     ▼                ▼
+┌────────────────┐  ┌────────────────────┐
+│ Exactly one    │  │ Anything else,     │
+│ --help or -h   │  │ including no args  │
+└───────┬────────┘  └─────────┬──────────┘
+        ▼                     ▼
+┌────────────────────┐  ┌────────────────────┐
+│ Show deprecation   │  │ Exit 2 before      │
+│ and canonical      │  │ rendering, network │
+│ handoff            │  │ access, or mutation│
+└────────────────────┘  └────────────────────┘
+```
+
 ## Fail-Closed Compatibility Contract
 
 This directory preserves only exact-name discovery and an actionable handoff. No legacy
@@ -28,7 +63,7 @@ Legacy reference and intake-template copies were removed so this alias cannot be
 for an independently maintained workflow. Do not reconstruct or execute an old rendered
 bundle. Read the canonical skill and collect inputs using its current contract.
 
-## Safe Compatibility Checks
+## Commands
 
 ```bash
 bash skills/splunk-kvstore-admin/scripts/setup.sh --help
@@ -46,3 +81,10 @@ bash skills/splunk-kvstore-admin-setup/scripts/validate.sh --help
 Any existing automation that supplies operational legacy flags must stop and be migrated
 to the canonical interface after reviewing its apply and acceptance gates. Do not infer a
 flag translation.
+
+## Troubleshooting
+
+| Failure | Meaning | Resolution |
+|---|---|---|
+| Exit status 2 | An operational legacy argument was refused | Read `splunk-kvstore-admin-setup` and migrate explicitly |
+| Canonical skill missing | The checkout is incomplete or stale | Refresh the canonical skill source before continuing |

--- a/skills/splunk-secure-gateway/SKILL.md
+++ b/skills/splunk-secure-gateway/SKILL.md
@@ -15,6 +15,41 @@ metadata:
 > `splunk-secure-gateway` is deprecated and replaced by
 > [`splunk-secure-gateway-setup`](../splunk-secure-gateway-setup/SKILL.md). Use the canonical skill for all work.
 
+## Prerequisites
+
+| Requirement | Purpose | Verify |
+|---|---|---|
+| Bash and Python 3 | Display the help-only compatibility handoff | `bash --version && python3 --version` |
+| Canonical replacement | Perform supported Secure Gateway work | `test -f skills/splunk-secure-gateway-setup/SKILL.md` |
+
+## When to Activate
+
+- An existing caller supplies the exact legacy name `splunk-secure-gateway`.
+- The caller needs the canonical replacement name before taking any action.
+
+Do not activate this alias for setup, rendering, validation, or live operations.
+
+## Workflow Overview
+
+```text
+┌──────────────────────────┐
+│ Compatibility invocation │
+└────────────┬─────────────┘
+             │
+     ┌───────┴────────┐
+     ▼                ▼
+┌────────────────┐  ┌────────────────────┐
+│ Exactly one    │  │ Anything else,     │
+│ --help or -h   │  │ including no args  │
+└───────┬────────┘  └─────────┬──────────┘
+        ▼                     ▼
+┌────────────────────┐  ┌────────────────────┐
+│ Show deprecation   │  │ Exit 2 before      │
+│ and canonical      │  │ rendering, network │
+│ handoff            │  │ access, or mutation│
+└────────────────────┘  └────────────────────┘
+```
+
 ## Fail-Closed Compatibility Contract
 
 This directory preserves only exact-name discovery and an actionable handoff. No legacy
@@ -28,7 +63,7 @@ Legacy reference and intake-template copies were removed so this alias cannot be
 for an independently maintained workflow. Do not reconstruct or execute an old rendered
 bundle. Read the canonical skill and collect inputs using its current contract.
 
-## Safe Compatibility Checks
+## Commands
 
 ```bash
 bash skills/splunk-secure-gateway/scripts/setup.sh --help
@@ -46,3 +81,10 @@ bash skills/splunk-secure-gateway-setup/scripts/validate.sh --help
 Any existing automation that supplies operational legacy flags must stop and be migrated
 to the canonical interface after reviewing its apply and acceptance gates. Do not infer a
 flag translation.
+
+## Troubleshooting
+
+| Failure | Meaning | Resolution |
+|---|---|---|
+| Exit status 2 | An operational legacy argument was refused | Read `splunk-secure-gateway-setup` and migrate explicitly |
+| Canonical skill missing | The checkout is incomplete or stale | Refresh the canonical skill source before continuing |

--- a/tests/check_skill_frontmatter.py
+++ b/tests/check_skill_frontmatter.py
@@ -38,6 +38,26 @@ MAX_DESCRIPTION_LENGTH = 1024
 MAX_COMPATIBILITY_LENGTH = 500
 MAX_SKILL_MD_LINES = 500
 MAX_BODY_WORDS = 5000
+MARKETPLACE_REQUIRED_BODY_SECTIONS = (
+    "Prerequisites",
+    "Workflow Overview",
+    "When to Activate",
+    "Troubleshooting",
+)
+MARKETPLACE_WORKFLOW_CODE_BLOCK_RE = re.compile(
+    r"^[ \t]*```[^\n]*\n(.*?)^[ \t]*```[ \t]*$",
+    re.MULTILINE | re.DOTALL,
+)
+MARKETPLACE_WORKFLOW_STRUCTURE_MARKERS = (
+    "┌",
+    "┐",
+    "└",
+    "┘",
+    "│",
+    "+--",
+    "--+",
+)
+MARKETPLACE_WORKFLOW_FLOW_MARKERS = ("▼", "▶", "→", "->")
 COMPATIBILITY_STATUSES = {
     "supported",
     "conditional",
@@ -222,6 +242,24 @@ def parse_frontmatter(block: str) -> dict[str, Any]:
     # Minimal fallback for local environments that have not installed
     # requirements-dev.txt yet. CI installs PyYAML and uses the full parser.
     return _fallback_mapping(block)
+
+
+def has_marketplace_workflow_diagram(workflow: str) -> bool:
+    """Return whether a workflow section contains a structured flow diagram."""
+
+    for code_block in MARKETPLACE_WORKFLOW_CODE_BLOCK_RE.findall(workflow):
+        structural_markers = {
+            marker
+            for marker in MARKETPLACE_WORKFLOW_STRUCTURE_MARKERS
+            if marker in code_block
+        }
+        has_flow_direction = any(
+            marker in code_block
+            for marker in MARKETPLACE_WORKFLOW_FLOW_MARKERS
+        )
+        if len(structural_markers) >= 2 and has_flow_direction:
+            return True
+    return False
 
 
 def check_openai_metadata(
@@ -508,6 +546,33 @@ def check_skill(skill_dir: Path, record: SkillRecord | None = None) -> list[str]
             f"{dir_name}: SKILL.md body has about {body_words} words; move "
             "detailed reference material to references/"
         )
+
+    if record is not None:
+        for section in MARKETPLACE_REQUIRED_BODY_SECTIONS:
+            if not re.search(rf"^## {re.escape(section)}", body, re.MULTILINE):
+                errors.append(
+                    f"{dir_name}: SKILL.md missing marketplace-required "
+                    f"{section!r} section"
+                )
+
+        if not re.search(r"^## (?:Examples|Commands)", body, re.MULTILINE):
+            errors.append(
+                f"{dir_name}: SKILL.md missing marketplace-required "
+                "Examples or Commands section"
+            )
+
+        workflow = re.search(
+            r"^## Workflow Overview[^\n]*\n(.*?)(?=^## |\Z)",
+            body,
+            re.MULTILINE | re.DOTALL,
+        )
+        if workflow is not None and not has_marketplace_workflow_diagram(
+            workflow.group(1)
+        ):
+            errors.append(
+                f"{dir_name}: SKILL.md Workflow Overview section "
+                "missing a marketplace workflow diagram"
+            )
 
     return errors
 

--- a/tests/test_skill_metadata_contract.py
+++ b/tests/test_skill_metadata_contract.py
@@ -5,6 +5,41 @@ from pathlib import Path
 from tests import check_skill_frontmatter as metadata_check
 
 
+def test_marketplace_workflow_diagram_accepts_structured_fenced_flows() -> None:
+    unicode_flow = """
+```text
+┌─────────┐
+│ Review  │
+└────┬────┘
+     ▼
+┌─────────┐
+│ Handoff │
+└─────────┘
+```
+"""
+    ascii_flow = """
+```text
++-- Review --+ -> +-- Handoff --+
+```
+"""
+
+    assert metadata_check.has_marketplace_workflow_diagram(unicode_flow)
+    assert metadata_check.has_marketplace_workflow_diagram(ascii_flow)
+
+
+def test_marketplace_workflow_diagram_rejects_weak_or_unfenced_markers() -> None:
+    invalid_workflows = (
+        "A stray │ glyph is not a workflow diagram.",
+        "```text\n│\n→\n```",
+        "```text\n│ │ →\n```",
+        "┌─────────┐ → ┌─────────┐",
+        "```text\n┌─────────┐\n│ Review  │\n└─────────┘\n```",
+    )
+
+    for workflow in invalid_workflows:
+        assert not metadata_check.has_marketplace_workflow_diagram(workflow)
+
+
 def test_fallback_parser_supports_nested_skill_and_interface_metadata(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## What

- add the required marketplace body sections and workflow diagrams to `cisco-collaboration-setup` and seven deprecated compatibility aliases
- keep every deprecated alias help-only and fail-closed
- add a source-side regression for required sections and structured fenced workflow diagrams

## Why

The marketplace importer correctly exposed eight source skills that did not satisfy its documented authoring contract. Fixing the canonical public source prevents source/export drift and lets the private marketplace refresh remain reproducible from an immutable source revision.

## Root cause

The source repository validated frontmatter and operational behavior, but did not enforce the marketplace body contract. The collaboration skill lacked an Examples/Commands heading and diagram; the compatibility aliases intentionally minimized their docs but omitted sections required of every marketplace skill.

## Impact

Documentation and validation only. The seven deprecated aliases retain their existing behavior: exactly one `--help`/`-h` request shows the canonical replacement, and operational invocations exit 2 before rendering, network access, or mutation.

## Checks

- `python -m pytest -q tests/test_skill_metadata_contract.py tests/test_deprecated_skill_aliases.py tests/test_cisco_collaboration_setup.py` — 321 passed
- `python tests/check_skill_frontmatter.py` — all 170 skills passed
- `python -m pytest -q tests/test_cloud_batch_uninstall.py` — 17 passed, 15 subtests passed
- credential/deployment regression files — 34 passed, 181 subtests passed
- `git diff --check`