### PR TITLE
chore: batch reviewed dependency updates

### DIFF
--- a/.github/workflows/aws-eks-o11y-staging.yml
+++ b/.github/workflows/aws-eks-o11y-staging.yml
@@ -82,7 +82,7 @@ jobs:
       KUBECONFIG: ${{ runner.temp }}/aws-eks-o11y-kubeconfig
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -120,7 +120,7 @@ jobs:
             --requirement "${requirements}"
 
       - name: Assume read-only staging role with OIDC
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.AWS_STAGING_ROLE_ARN }}
           role-session-name: o11y-staging-${{ github.run_id }}
@@ -223,7 +223,7 @@ jobs:
 
       - name: Upload sanitized acceptance report
         if: ${{ always() }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aws-eks-o11y-staging-${{ github.run_id }}
           path: ${{ runner.temp }}/aws-eks-o11y-staging-report.json

--- a/.github/workflows/catalog-drift.yml
+++ b/.github/workflows/catalog-drift.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Compare registry with live Splunkbase listings
         run: >-
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Compare pinned SCAN catalog provenance with the public source
         run: >-
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Compare the Galileo MCP server with the pinned tool catalog
         run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -80,7 +80,7 @@ jobs:
         python-version: ["3.10", "3.14"]
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Bats
         run: |
@@ -124,7 +124,7 @@ jobs:
       GITLEAKS_LINUX_X64_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
     steps:
       - name: Check out complete repository history
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -157,7 +157,7 @@ jobs:
       SHELLCHECK_SHA256: "6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87"
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install ShellCheck
         run: |
@@ -205,7 +205,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/requirements-agent.txt
+++ b/requirements-agent.txt
@@ -4,8 +4,8 @@ mcp==1.28.1
 PyYAML==6.0.3
 # Security-reviewed MCP runtime transitive floor, pinned after pip-audit.
 cryptography==50.0.0
-idna==3.15
+idna==3.18
 pydantic-settings==2.14.2
 PyJWT[crypto]==2.13.0
-python-multipart==0.0.31
+python-multipart==0.0.32
 starlette==1.3.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest>=9.0.3,<10
+pytest>=9.1.1,<10
 jsonschema>=4.25,<5
 pip-audit==2.10.1
 PyYAML>=6,<7
@@ -8,4 +8,4 @@ ruff==0.15.20
 yamllint>=1.35,<2
 defusedxml>=0.7,<1
 # Optional: enables `pre-commit install` per CONTRIBUTING.md.
-pre-commit>=3.5,<5
+pre-commit>=4.6.1,<5


### PR DESCRIPTION
## Summary

- consolidate the reviewed updates from Dependabot PRs #48–#54
- update pinned GitHub Actions and Python dependencies
- retain the intentional Ruff 0.15.20 baseline pin

## Validation

- `git diff --check`
- `yamllint .github/workflows/aws-eks-o11y-staging.yml .github/workflows/catalog-drift.yml .github/workflows/ci.yml`
- GitHub Actions required checks pending