### PR TITLE
Fix EKS workflow validation and lint workflows

### DIFF
--- a/.github/workflows/aws-eks-o11y-staging.yml
+++ b/.github/workflows/aws-eks-o11y-staging.yml
@@ -79,7 +79,6 @@ jobs:
       COLLECTOR_RELEASE: ${{ inputs.collector_release }}
       INSTRUMENTATION_NAME: splunk-otel-staging
       WORKLOAD_LANGUAGE: ${{ inputs.language }}
-      KUBECONFIG: ${{ runner.temp }}/aws-eks-o11y-kubeconfig
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -99,6 +98,13 @@ jobs:
           [[ "${STAGING_WORKLOAD}" =~ ^(Deployment|StatefulSet|DaemonSet)/[a-z0-9]([-a-z0-9.]*[a-z0-9])?$ ]]
           [[ ! "${STAGING_APM_SERVICE}" =~ [[:cntrl:]] ]]
           [[ "${STAGING_APM_SERVICE}" =~ ^[^[:space:][:cntrl:]](.*[^[:space:][:cntrl:]])?$ ]]
+
+      - name: Initialize private runtime paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf 'KUBECONFIG=%s\n' \
+            "${RUNNER_TEMP}/aws-eks-o11y-kubeconfig" >> "${GITHUB_ENV}"
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,25 @@ jobs:
       - name: Install validation tools
         run: pip install -r requirements-dev.txt
 
+      - name: Install pinned actionlint
+        shell: bash
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_LINUX_X64_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        run: |
+          set -euo pipefail
+          archive="${RUNNER_TEMP}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl --proto '=https' --tlsv1.2 --silent --show-error --fail --location \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            --output "${archive}"
+          echo "${ACTIONLINT_LINUX_X64_SHA256}  ${archive}" | sha256sum -c -
+          tar -xzf "${archive}" -C "${RUNNER_TEMP}" actionlint
+          chmod 0755 "${RUNNER_TEMP}/actionlint"
+
+      - name: Validate GitHub Actions workflows
+        run: |
+          "${RUNNER_TEMP}/actionlint"
+
       - name: Validate all tracked JSON and YAML
         run: python3 scripts/validate_tracked_configs.py --yamllint
 

--- a/tests/test_aws_eks_o11y_staging_workflow.py
+++ b/tests/test_aws_eks_o11y_staging_workflow.py
@@ -116,7 +116,12 @@ def test_workflow_is_manual_approved_read_only_and_immutably_pinned() -> None:
     assert "36e2f4ac66259232341dd7866952d64a958846470f6a9a6a813b9117bd965207" in text
     assert "scripts/staging/validate-aws-eks-o11y.sh" in text
     assert "SPLUNK_O11Y_TOKEN_FILE" in text
-    assert "KUBECONFIG: ${{ runner.temp }}/aws-eks-o11y-kubeconfig" in text
+    assert "KUBECONFIG: ${{ runner.temp }}/aws-eks-o11y-kubeconfig" not in text
+    runtime_path_step = next(
+        step for step in job["steps"] if step["name"] == "Initialize private runtime paths"
+    )
+    assert '"${RUNNER_TEMP}/aws-eks-o11y-kubeconfig"' in runtime_path_step["run"]
+    assert '>> "${GITHUB_ENV}"' in runtime_path_step["run"]
     assert 'chmod 600 "${KUBECONFIG}"' in text
     assert "rm -f --" in text
     cleanup_index = next(


### PR DESCRIPTION
## What changed

- move the EKS staging `KUBECONFIG` initialization into a step where the `runner` context is valid
- add pinned, checksum-verified `actionlint` validation to CI
- update the workflow contract test for the runtime path setup

## Why

GitHub rejected the manual EKS staging workflow before job creation because `runner.temp` was referenced from job-level `env`, where the `runner` context is unavailable. That produced misleading zero-job failures on every push.

## Validation

- `actionlint` v1.7.12 passes across all workflows
- `pytest tests/test_aws_eks_o11y_staging_workflow.py -q` passes (9 tests)
- tracked JSON/YAML validation and YAML lint pass