### PR TITLE
Migrate local MCP server to SDK v2 and update Ruff

### DIFF
--- a/agent/splunk_cisco_skills_mcp/server.py
+++ b/agent/splunk_cisco_skills_mcp/server.py
@@ -1,4 +1,4 @@
-"""FastMCP stdio server exposing this repository as agent tools."""
+"""MCP v2 stdio server exposing this repository as agent tools."""
 
 from __future__ import annotations
 
@@ -11,13 +11,15 @@ from contextlib import asynccontextmanager
 from typing import Annotated, Any, Literal, TypeVar
 
 import anyio
-import mcp.server.session as mcp_server_session
-from mcp import types as mcp_types
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.utilities.func_metadata import func_metadata
-from mcp.shared.exceptions import McpError
+from mcp import MCPError, types as mcp_types
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.server.mcpserver.exceptions import (
+    ResourceNotFoundError,
+    ToolError,
+    UnexpectedToolError,
+)
+from mcp.server.mcpserver.utilities.func_metadata import func_metadata
 from mcp.shared.message import SessionMessage
-from mcp.shared.session import RequestResponder
 from mcp.types import CallToolResult, TextContent
 from pydantic import Field, StrictBool, StrictInt, StrictStr, ValidationError
 
@@ -60,8 +62,8 @@ class _DuplicateJSONKey(ValueError):
     """Raised when an inbound JSON object has ambiguous duplicate keys."""
 
 
-def _model_method_names(model: Any) -> frozenset[str]:
-    schema = model.model_json_schema()
+def _model_method_names(adapter: Any) -> frozenset[str]:
+    schema = adapter.json_schema()
     methods = {
         definition["properties"]["method"]["const"]
         for definition in schema.get("$defs", {}).values()
@@ -73,8 +75,8 @@ def _model_method_names(model: Any) -> frozenset[str]:
     return frozenset(methods)
 
 
-_CLIENT_REQUEST_METHODS = _model_method_names(mcp_types.ClientRequest)
-_CLIENT_NOTIFICATION_METHODS = _model_method_names(mcp_types.ClientNotification)
+_CLIENT_REQUEST_METHODS = _model_method_names(mcp_types.client_request_adapter)
+_CLIENT_NOTIFICATION_METHODS = _model_method_names(mcp_types.client_notification_adapter)
 
 
 async def _shutdown_core_processes() -> None:
@@ -88,7 +90,7 @@ async def _shutdown_core_processes() -> None:
 
 
 @asynccontextmanager
-async def _server_lifespan(_: FastMCP[Any]) -> AsyncIterator[dict[str, Any]]:
+async def _server_lifespan(_: MCPServer[Any]) -> AsyncIterator[dict[str, Any]]:
     """Ensure tracked subprocesses cannot outlive the stdio server."""
     try:
         yield {}
@@ -143,17 +145,16 @@ def _validate_json_shape(payload: Any) -> None:
             stack.extend((item, depth + 1) for item in value)
 
 
-def _exception_chain_contains(
-    error: BaseException, kinds: type[BaseException] | tuple[type[BaseException], ...]
-) -> bool:
+def _expected_tool_error(error: BaseException) -> BaseException | None:
+    """Return a reviewed, user-presentable error from a chained tool failure."""
     seen: set[int] = set()
     current: BaseException | None = error
     while current is not None and id(current) not in seen:
         seen.add(id(current))
-        if isinstance(current, kinds):
-            return True
+        if isinstance(current, (core.SkillMCPError, discovery.DiscoveryError)):
+            return current
         current = current.__cause__ or current.__context__
-    return False
+    return None
 
 
 @asynccontextmanager
@@ -248,9 +249,13 @@ async def _bounded_stdio_server() -> AsyncIterator[tuple[Any, Any]]:
                                 continue
                             try:
                                 if is_request:
-                                    mcp_types.ClientRequest.model_validate(payload)
+                                    mcp_types.client_request_adapter.validate_python(
+                                        payload, by_name=False
+                                    )
                                 else:
-                                    mcp_types.ClientNotification.model_validate(payload)
+                                    mcp_types.client_notification_adapter.validate_python(
+                                        payload, by_name=False
+                                    )
                             except ValidationError:
                                 if is_request:
                                     await write_stream.send(
@@ -262,7 +267,9 @@ async def _bounded_stdio_server() -> AsyncIterator[tuple[Any, Any]]:
                                     )
                                 continue
                     try:
-                        message = mcp_types.JSONRPCMessage.model_validate(payload)
+                        message = mcp_types.jsonrpc_message_adapter.validate_python(
+                            payload, by_name=False
+                        )
                     except ValidationError:
                         await write_stream.send(
                             _protocol_error_line(-32600, "Invalid Request.")
@@ -297,81 +304,91 @@ async def _bounded_stdio_server() -> AsyncIterator[tuple[Any, Any]]:
         yield read_stream, write_stream
 
 
-mcp = FastMCP(
+class _SkillsMCPServer(MCPServer[dict[str, Any]]):
+    """Preserve the repository's strict, value-free protocol error boundary."""
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: Context[dict[str, Any], Any] | None = None,
+    ) -> CallToolResult:
+        tool = self._tool_manager._tools.get(name)
+        if tool is None:
+            raise MCPError(
+                code=mcp_types.INVALID_PARAMS,
+                message="Unknown tool name.",
+            )
+        try:
+            prepared = tool.fn_metadata.pre_parse_json(arguments)
+            tool.fn_metadata.arg_model.model_validate(prepared)
+        except (ValidationError, ValueError, TypeError, json.JSONDecodeError) as exc:
+            raise MCPError(
+                code=mcp_types.INVALID_PARAMS,
+                message="Invalid tool arguments; review the published input schema.",
+            ) from exc
+        try:
+            return await super().call_tool(name, arguments, context)
+        except UnexpectedToolError as exc:
+            expected = _expected_tool_error(exc)
+            if expected is not None:
+                raise ToolError(str(expected)) from exc
+            raise
+
+    async def read_resource(
+        self,
+        uri: str,
+        context: Context[dict[str, Any], Any] | None = None,
+    ) -> Any:
+        resources = self._resource_manager._resources
+        templates = self._resource_manager._templates
+        known = uri in resources or any(
+            template.matches(uri) is not None for template in templates.values()
+        )
+        if not known:
+            raise MCPError(
+                code=mcp_types.INVALID_PARAMS,
+                message="Resource not found.",
+            )
+        try:
+            return await super().read_resource(uri, context)
+        except ResourceNotFoundError as exc:
+            raise MCPError(
+                code=mcp_types.INVALID_PARAMS,
+                message="Resource not found.",
+            ) from exc
+
+    async def get_prompt(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        context: Context[dict[str, Any], Any] | None = None,
+    ) -> Any:
+        prompt = self._prompt_manager.get_prompt(name)
+        if prompt is None:
+            raise MCPError(
+                code=mcp_types.INVALID_PARAMS,
+                message="Unknown prompt name.",
+            )
+        try:
+            metadata = func_metadata(getattr(prompt.fn, "raw_function", prompt.fn))
+            prepared = metadata.pre_parse_json(arguments or {})
+            metadata.arg_model.model_validate(prepared)
+        except (ValidationError, ValueError, TypeError, json.JSONDecodeError) as exc:
+            raise MCPError(
+                code=mcp_types.INVALID_PARAMS,
+                message="Invalid prompt arguments; review the published arguments.",
+            ) from exc
+        return await super().get_prompt(name, arguments, context)
+
+
+mcp = _SkillsMCPServer(
     "splunk-cisco-skills",
     instructions=SERVER_INSTRUCTIONS,
+    version=SERVER_VERSION,
     lifespan=_server_lifespan,
     log_level="WARNING",
 )
-
-
-def _set_server_contract_version(server: FastMCP[Any]) -> None:
-    """Isolate the one private FastMCP v1 hook used for server versioning."""
-    low_level_server = getattr(server, "_mcp_server", None)
-    if low_level_server is None or not hasattr(low_level_server, "version"):
-        raise RuntimeError(
-            "Unsupported MCP SDK: FastMCP no longer exposes the v1 server-version hook."
-        )
-    low_level_server.version = SERVER_VERSION
-
-
-def _exclude_batch_required_protocol_version() -> None:
-    """Do not negotiate MCP 2025-03-26 with the SDK v1 stdio JSON-line reader.
-
-    MCP 2025-03-26 requires receivers to accept JSON-RPC batches, while the pinned
-    SDK's stdio reader accepts one JSON-RPC object per line. Newer MCP revisions
-    removed batching. FastMCP v1 has no public protocol-version configuration, so
-    this asserted compatibility hook is intentionally isolated here.
-    """
-    supported = getattr(mcp_server_session, "SUPPORTED_PROTOCOL_VERSIONS", None)
-    if not isinstance(supported, list):
-        raise RuntimeError(
-            "Unsupported MCP SDK: cannot constrain negotiated protocol versions."
-        )
-    supported[:] = [version for version in supported if version != "2025-03-26"]
-    if "2025-03-26" in supported:  # pragma: no cover - defensive assertion
-        raise RuntimeError("Failed to disable MCP 2025-03-26 negotiation.")
-
-
-_ORIGINAL_REQUEST_RESPONDER_ENTER = getattr(
-    RequestResponder,
-    "_splunk_skills_original_enter",
-    RequestResponder.__enter__,
-)
-
-
-def _enter_request_with_pending_cancel(responder: Any) -> Any:
-    entered = _ORIGINAL_REQUEST_RESPONDER_ENTER(responder)
-    if getattr(responder, "_cancel_pending", False):
-        responder._cancel_scope.cancel()
-    return entered
-
-
-async def _cancel_request_without_response(responder: Any) -> None:
-    """Apply MCP fire-and-forget cancellation semantics for SDK v1."""
-    responder._completed = True
-    if responder._entered:
-        responder._cancel_scope.cancel()
-    else:
-        responder._cancel_pending = True
-
-
-def _install_cancellation_semantics() -> None:
-    """Prevent SDK v1 from emitting its non-standard code-0 cancel response."""
-    if not inspect.iscoroutinefunction(getattr(RequestResponder, "cancel", None)):
-        raise RuntimeError("Unsupported MCP SDK cancellation contract.")
-    if not callable(getattr(RequestResponder, "__enter__", None)):
-        raise RuntimeError("Unsupported MCP SDK request context contract.")
-    RequestResponder._splunk_skills_original_enter = (  # type: ignore[attr-defined]
-        _ORIGINAL_REQUEST_RESPONDER_ENTER
-    )
-    RequestResponder.__enter__ = _enter_request_with_pending_cancel
-    RequestResponder.cancel = _cancel_request_without_response
-
-
-_exclude_batch_required_protocol_version()
-_install_cancellation_semantics()
-_set_server_contract_version(mcp)
 
 _read_worker_limiter = anyio.CapacityLimiter(READ_WORKER_LIMIT)
 _subprocess_worker_limiter = anyio.CapacityLimiter(SUBPROCESS_WORKER_LIMIT)
@@ -470,8 +487,8 @@ async def _run_cancellable(operation: Callable[[core.CommandCancellation], T]) -
 def _execution_result(payload: dict[str, Any]) -> CallToolResult:
     return CallToolResult(
         content=[TextContent(type="text", text=_json_resource(payload))],
-        structuredContent=payload,
-        isError=not bool(payload.get("ok")),
+        structured_content=payload,
+        is_error=not bool(payload.get("ok")),
     )
 
 
@@ -510,6 +527,27 @@ DiscoveryReadBytes = Annotated[
 ]
 
 
+async def _read_legacy_skill_resource(
+    skill: str,
+    kind: discovery.SkillFileKind,
+) -> str:
+    """Read a legacy resource while preserving its sanitized protocol errors."""
+    try:
+        return await _run_blocking(
+            lambda: _bounded_legacy_skill_resource(skill, kind)
+        )
+    except discovery.DiscoveryNotFound as exc:
+        raise ResourceNotFoundError("Resource not found.") from exc
+    except (
+        discovery.InvalidDiscoveryRequest,
+        discovery.UnsafeDiscoveryPath,
+    ) as exc:
+        raise MCPError(
+            code=mcp_types.INVALID_PARAMS,
+            message="Invalid resource identifier.",
+        ) from exc
+
+
 @mcp.resource(
     "skills://catalog",
     title="Splunk and Cisco skill catalog",
@@ -536,9 +574,7 @@ async def skills_catalog() -> str:
 )
 async def skill_instructions(skill: str) -> str:
     """Return a skill's SKILL.md instructions."""
-    return await _run_blocking(
-        lambda: _bounded_legacy_skill_resource(skill, "instructions")
-    )
+    return await _read_legacy_skill_resource(skill, "instructions")
 
 
 @mcp.resource(
@@ -552,9 +588,7 @@ async def skill_instructions(skill: str) -> str:
 )
 async def skill_reference(skill: str) -> str:
     """Return a skill's reference.md file or aggregated references/*.md files."""
-    return await _run_blocking(
-        lambda: _bounded_legacy_skill_resource(skill, "reference")
-    )
+    return await _read_legacy_skill_resource(skill, "reference")
 
 
 @mcp.resource(
@@ -568,9 +602,7 @@ async def skill_reference(skill: str) -> str:
 )
 async def skill_template(skill: str) -> str:
     """Return a skill's template.example file or aggregated templates/* files."""
-    return await _run_blocking(
-        lambda: _bounded_legacy_skill_resource(skill, "template")
-    )
+    return await _read_legacy_skill_resource(skill, "template")
 
 
 @mcp.tool(
@@ -925,12 +957,12 @@ def review_skill_script_plan(skill: SkillName, script: ScriptName) -> str:
 
 
 def _enforce_strict_tool_arguments() -> None:
-    """Reject unknown properties through an asserted FastMCP v1 compatibility hook."""
+    """Reject unknown tool properties through the retained MCPServer metadata hook."""
     tool_manager = getattr(mcp, "_tool_manager", None)
     tools = getattr(tool_manager, "_tools", None)
     if not isinstance(tools, dict):
         raise RuntimeError(
-            "Unsupported MCP SDK: FastMCP no longer exposes the v1 tool-schema hook."
+            "Unsupported MCP SDK: MCPServer does not expose tool metadata."
         )
     for tool in tools.values():
         if not hasattr(tool, "fn_metadata") or not hasattr(tool, "parameters"):
@@ -943,182 +975,8 @@ def _enforce_strict_tool_arguments() -> None:
 _enforce_strict_tool_arguments()
 
 
-def _install_protocol_error_guards() -> None:
-    """Sanitize validation failures and restore MCP-defined error codes.
-
-    FastMCP v1 includes Pydantic's rejected ``input_value`` in tool errors,
-    which can echo a credential that a client mistakenly placed in malformed
-    input. It also represents an unknown tool as a successful JSON-RPC call
-    whose tool result has ``isError=true``, and maps resource failures to the
-    non-standard error code 0. Validate before those handlers and emit small,
-    value-free protocol errors instead.
-    """
-    low_level_server = getattr(mcp, "_mcp_server", None)
-    tool_manager = getattr(mcp, "_tool_manager", None)
-    resource_manager = getattr(mcp, "_resource_manager", None)
-    prompt_manager = getattr(mcp, "_prompt_manager", None)
-    handlers = getattr(low_level_server, "request_handlers", None)
-    tools = getattr(tool_manager, "_tools", None)
-    resources = getattr(resource_manager, "_resources", None)
-    templates = getattr(resource_manager, "_templates", None)
-    prompts = getattr(prompt_manager, "_prompts", None)
-    if not (
-        isinstance(handlers, dict)
-        and isinstance(tools, dict)
-        and isinstance(resources, dict)
-        and isinstance(templates, dict)
-        and isinstance(prompts, dict)
-    ):
-        raise RuntimeError(
-            "Unsupported MCP SDK: FastMCP no longer exposes the v1 protocol hooks."
-        )
-
-    original_call_tool = handlers.get(mcp_types.CallToolRequest)
-    original_read_resource = handlers.get(mcp_types.ReadResourceRequest)
-    original_get_prompt = handlers.get(mcp_types.GetPromptRequest)
-    if not (
-        callable(original_call_tool)
-        and callable(original_read_resource)
-        and callable(original_get_prompt)
-    ):
-        raise RuntimeError("Unsupported MCP SDK request-handler contract.")
-    prompt_metadata = {
-        name: func_metadata(getattr(prompt.fn, "raw_function", prompt.fn))
-        for name, prompt in prompts.items()
-    }
-
-    async def guarded_call_tool(
-        request: mcp_types.CallToolRequest,
-    ) -> mcp_types.ServerResult:
-        tool = tools.get(request.params.name)
-        if tool is None:
-            raise McpError(
-                mcp_types.ErrorData(
-                    code=mcp_types.INVALID_PARAMS,
-                    message="Unknown tool name.",
-                )
-            )
-        arguments = request.params.arguments or {}
-        try:
-            prepared = tool.fn_metadata.pre_parse_json(arguments)
-            tool.fn_metadata.arg_model.model_validate(prepared)
-        except (ValidationError, ValueError, TypeError, json.JSONDecodeError) as exc:
-            raise McpError(
-                mcp_types.ErrorData(
-                    code=mcp_types.INVALID_PARAMS,
-                    message="Invalid tool arguments; review the published input schema.",
-                )
-            ) from exc
-        return await original_call_tool(request)
-
-    async def guarded_read_resource(
-        request: mcp_types.ReadResourceRequest,
-    ) -> mcp_types.ServerResult:
-        uri = str(request.params.uri)
-        known = uri in resources or any(
-            template.matches(uri) is not None for template in templates.values()
-        )
-        if not known:
-            raise McpError(
-                mcp_types.ErrorData(code=-32002, message="Resource not found.")
-            )
-        try:
-            resource = await resource_manager.get_resource(
-                request.params.uri,
-                context=mcp.get_context(),
-            )
-            content = await resource.read()
-        except discovery.DiscoveryNotFound as exc:
-            raise McpError(
-                mcp_types.ErrorData(
-                    code=-32002,
-                    message="Resource not found.",
-                )
-            ) from exc
-        except (
-            discovery.InvalidDiscoveryRequest,
-            discovery.UnsafeDiscoveryPath,
-        ) as exc:
-            raise McpError(
-                mcp_types.ErrorData(
-                    code=mcp_types.INVALID_PARAMS,
-                    message="Invalid resource identifier.",
-                )
-            ) from exc
-        except Exception as exc:
-            if _exception_chain_contains(exc, discovery.DiscoveryNotFound):
-                raise McpError(
-                    mcp_types.ErrorData(code=-32002, message="Resource not found.")
-                ) from exc
-            if _exception_chain_contains(
-                exc,
-                (
-                    discovery.InvalidDiscoveryRequest,
-                    discovery.UnsafeDiscoveryPath,
-                ),
-            ):
-                raise McpError(
-                    mcp_types.ErrorData(
-                        code=mcp_types.INVALID_PARAMS,
-                        message="Invalid resource identifier.",
-                    )
-                ) from exc
-            raise McpError(
-                mcp_types.ErrorData(
-                    code=mcp_types.INTERNAL_ERROR,
-                    message="Resource read failed.",
-                )
-            ) from exc
-        if not isinstance(content, str):
-            raise McpError(
-                mcp_types.ErrorData(
-                    code=mcp_types.INTERNAL_ERROR,
-                    message="Resource returned an unsupported content type.",
-                )
-            )
-        meta = getattr(resource, "meta", None)
-        contents = mcp_types.TextResourceContents(
-            uri=request.params.uri,
-            text=content,
-            mimeType=getattr(resource, "mime_type", None) or "text/plain",
-            **({"_meta": meta} if meta is not None else {}),
-        )
-        return mcp_types.ServerResult(mcp_types.ReadResourceResult(contents=[contents]))
-
-    async def guarded_get_prompt(
-        request: mcp_types.GetPromptRequest,
-    ) -> mcp_types.ServerResult:
-        metadata = prompt_metadata.get(request.params.name)
-        if metadata is None:
-            raise McpError(
-                mcp_types.ErrorData(
-                    code=mcp_types.INVALID_PARAMS,
-                    message="Unknown prompt name.",
-                )
-            )
-        arguments = request.params.arguments or {}
-        try:
-            prepared = metadata.pre_parse_json(arguments)
-            metadata.arg_model.model_validate(prepared)
-        except (ValidationError, ValueError, TypeError, json.JSONDecodeError) as exc:
-            raise McpError(
-                mcp_types.ErrorData(
-                    code=mcp_types.INVALID_PARAMS,
-                    message="Invalid prompt arguments; review the published arguments.",
-                )
-            ) from exc
-        return await original_get_prompt(request)
-
-    handlers[mcp_types.CallToolRequest] = guarded_call_tool
-    handlers[mcp_types.ReadResourceRequest] = guarded_read_resource
-    handlers[mcp_types.GetPromptRequest] = guarded_get_prompt
-
-
-_install_protocol_error_guards()
-
-
 async def _run_stdio_server() -> None:
-    low_level_server = getattr(mcp, "_mcp_server", None)
+    low_level_server = getattr(mcp, "_lowlevel_server", None)
     if low_level_server is None:
         raise RuntimeError("Unsupported MCP SDK: low-level server hook is unavailable.")
     async with _bounded_stdio_server() as (read_stream, write_stream):

--- a/agent/splunk_cisco_skills_mcp/server.py
+++ b/agent/splunk_cisco_skills_mcp/server.py
@@ -21,6 +21,7 @@ from mcp.server.mcpserver.exceptions import (
 from mcp.server.mcpserver.utilities.func_metadata import func_metadata
 from mcp.shared.message import SessionMessage
 from mcp.types import CallToolResult, TextContent
+from mcp_types.version import LATEST_HANDSHAKE_VERSION
 from pydantic import Field, StrictBool, StrictInt, StrictStr, ValidationError
 
 from . import core, discovery
@@ -51,6 +52,7 @@ LEGACY_RESOURCE_BYTES = discovery.MAX_READ_BYTES
 MAX_STDIO_FRAME_BYTES = 1024 * 1024
 MAX_STDIO_JSON_DEPTH = 64
 MAX_STDIO_JSON_ITEMS = 100_000
+BATCH_REQUIRED_PROTOCOL_VERSION = "2025-03-26"
 T = TypeVar("T")
 
 
@@ -145,6 +147,22 @@ def _validate_json_shape(payload: Any) -> None:
             stack.extend((item, depth + 1) for item in value)
 
 
+def _replace_batch_required_protocol_offer(payload: Any) -> Any:
+    """Counter-offer a protocol compatible with the bounded JSON-line transport."""
+    if not isinstance(payload, dict) or payload.get("method") != "initialize":
+        return payload
+    params = payload.get("params")
+    if not isinstance(params, dict) or params.get("protocolVersion") != (
+        BATCH_REQUIRED_PROTOCOL_VERSION
+    ):
+        return payload
+    normalized = dict(payload)
+    normalized_params = dict(params)
+    normalized_params["protocolVersion"] = LATEST_HANDSHAKE_VERSION
+    normalized["params"] = normalized_params
+    return normalized
+
+
 def _expected_tool_error(error: BaseException) -> BaseException | None:
     """Return a reviewed, user-presentable error from a chained tool failure."""
     seen: set[int] = set()
@@ -217,6 +235,7 @@ async def _bounded_stdio_server() -> AsyncIterator[tuple[Any, Any]]:
                             _protocol_error_line(-32600, "Invalid Request.")
                         )
                         continue
+                    payload = _replace_batch_required_protocol_offer(payload)
                     if isinstance(payload, dict) and isinstance(
                         payload.get("method"), str
                     ):
@@ -340,16 +359,6 @@ class _SkillsMCPServer(MCPServer[dict[str, Any]]):
         uri: str,
         context: Context[dict[str, Any], Any] | None = None,
     ) -> Any:
-        resources = self._resource_manager._resources
-        templates = self._resource_manager._templates
-        known = uri in resources or any(
-            template.matches(uri) is not None for template in templates.values()
-        )
-        if not known:
-            raise MCPError(
-                code=mcp_types.INVALID_PARAMS,
-                message="Resource not found.",
-            )
         try:
             return await super().read_resource(uri, context)
         except ResourceNotFoundError as exc:

--- a/requirements-agent.txt
+++ b/requirements-agent.txt
@@ -1,6 +1,6 @@
-# MCP SDK 2.x is a breaking rewrite; keep the FastMCP v1 contract until migrated.
+# MCP SDK 2.x is the supported local skills MCP runtime.
 pip==26.2.1
-mcp>=1.28.1,<2
+mcp>=2.1.0,<3
 PyYAML==6.0.3
 # Security-reviewed MCP runtime transitive floor, pinned after pip-audit.
 cryptography==50.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,9 +2,8 @@ pytest>=9.1.1,<10
 jsonschema>=4.26.0,<5
 pip-audit==2.10.1
 PyYAML>=6,<7
-# Pin until the repository's legacy lint baseline is intentionally migrated;
-# Ruff 0.16 changes default rule behavior and exposes unrelated existing findings.
-ruff>=0.15.20,<0.16
+# Ruff 0.16's rule selection is configured explicitly in ruff.toml.
+ruff>=0.16.4,<0.17
 yamllint>=1.38.0,<2
 defusedxml>=0.7.1,<1
 # Optional: enables `pre-commit install` per CONTRIBUTING.md.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,5 @@
+[lint]
+# Ruff 0.16 enables every stable rule family when no selection is configured.
+# Keep the repository's established Pyflakes/pycodestyle baseline explicit; new
+# rule families can be adopted in focused, reviewable migrations.
+select = ["E4", "E7", "E9", "F"]

--- a/tests/test_agent_mcp_protocol.py
+++ b/tests/test_agent_mcp_protocol.py
@@ -15,16 +15,15 @@ from typing import AsyncIterator
 from skills.shared.skill_catalog import load_catalog
 
 try:
-    from mcp import ClientSession, StdioServerParameters, types as mcp_types
+    from mcp import MCPError, ClientSession, StdioServerParameters, types as mcp_types
     from mcp.client.stdio import stdio_client
-    from mcp.shared.exceptions import McpError
 except (
     ModuleNotFoundError
 ):  # pragma: no cover - requirements-agent.txt supplies MCP in CI
     ClientSession = None  # type: ignore[assignment,misc]
     StdioServerParameters = None  # type: ignore[assignment,misc]
     mcp_types = None  # type: ignore[assignment]
-    McpError = Exception  # type: ignore[assignment,misc]
+    MCPError = Exception  # type: ignore[assignment,misc]
     stdio_client = None  # type: ignore[assignment]
 
 
@@ -42,8 +41,8 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
         *,
         expected_message: str = "Invalid tool arguments",
         absent_values: tuple[str, ...] = (),
-    ) -> McpError:
-        with self.assertRaises(McpError) as raised:
+    ) -> MCPError:
+        with self.assertRaises(MCPError) as raised:
             await client.call_tool(name, arguments)
 
         error = raised.exception.error
@@ -94,9 +93,9 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
     async def test_initialize_advertises_stable_server_contract(self) -> None:
         async with self.session() as _client:
             initialized = self.initialized
-            self.assertEqual(initialized.serverInfo.name, "splunk-cisco-skills")
-            self.assertEqual(initialized.serverInfo.version, "1.1.0")
-            self.assertNotEqual(initialized.protocolVersion, "2025-03-26")
+            self.assertEqual(initialized.server_info.name, "splunk-cisco-skills")
+            self.assertEqual(initialized.server_info.version, "1.1.0")
+            self.assertNotEqual(initialized.protocol_version, "2025-03-26")
             self.assertIn(
                 "SPLUNK_SKILLS_MCP_ENABLE_EXECUTION=1", initialized.instructions
             )
@@ -104,9 +103,9 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
                 "SPLUNK_SKILLS_MCP_ALLOW_GENERIC_EXECUTION=1",
                 initialized.instructions,
             )
-            self.assertFalse(initialized.capabilities.tools.listChanged)
+            self.assertFalse(initialized.capabilities.tools.list_changed)
             self.assertFalse(initialized.capabilities.resources.subscribe)
-            self.assertFalse(initialized.capabilities.prompts.listChanged)
+            self.assertFalse(initialized.capabilities.prompts.list_changed)
 
     async def test_tool_schemas_are_strict_and_publish_constraints(self) -> None:
         async with self.session() as client:
@@ -133,9 +132,9 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
         )
         for tool in tools.values():
             with self.subTest(tool=tool.name):
-                self.assertIs(tool.inputSchema.get("additionalProperties"), False)
+                self.assertIs(tool.input_schema.get("additionalProperties"), False)
 
-        product_plan = tools["plan_cisco_product_setup"].inputSchema["properties"]
+        product_plan = tools["plan_cisco_product_setup"].input_schema["properties"]
         self.assertEqual(
             product_plan["phase"]["enum"],
             ["full", "install", "configure", "validate"],
@@ -154,20 +153,20 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
             product_plan["set_values"]["anyOf"][0]["propertyNames"]["maxLength"],
             255,
         )
-        plan_hash = tools["execute_skill_script"].inputSchema["properties"]["plan_hash"]
+        plan_hash = tools["execute_skill_script"].input_schema["properties"]["plan_hash"]
         self.assertEqual(plan_hash["pattern"], "^[0-9a-f]{64}$")
 
         self.assertEqual(
-            tools["execute_skill_script"].inputSchema["properties"]["confirm"]["type"],
+            tools["execute_skill_script"].input_schema["properties"]["confirm"]["type"],
             "boolean",
         )
-        search = tools["search_skills"].inputSchema["properties"]
+        search = tools["search_skills"].input_schema["properties"]
         self.assertEqual(search["limit"]["minimum"], 1)
         self.assertEqual(search["limit"]["maximum"], 100)
         self.assertIn("canonical", tools["search_skills"].description)
         self.assertIn("exact legacy name", tools["search_skills"].description)
         self.assertIn("canonical", tools["list_skills"].description)
-        read = tools["read_skill_file"].inputSchema["properties"]
+        read = tools["read_skill_file"].input_schema["properties"]
         self.assertEqual(read["offset"]["minimum"], 0)
         self.assertEqual(read["max_bytes"]["minimum"], 1)
         self.assertEqual(read["max_bytes"]["maximum"], 262144)
@@ -271,31 +270,31 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
                 else:
                     os.environ[name] = value
 
-        self.assertFalse(status.isError)
-        self.assertEqual(status.structuredContent["server"]["version"], "1.1.0")
+        self.assertFalse(status.is_error)
+        self.assertEqual(status.structured_content["server"]["version"], "1.1.0")
         self.assertEqual(
-            status.structuredContent["gates"],
+            status.structured_content["gates"],
             {
                 "execution_enabled": False,
                 "generic_execution_enabled": False,
                 "mutation_enabled": False,
             },
         )
-        self.assertFalse(resolved.isError)
-        self.assertEqual(resolved.structuredContent["status"], "resolved")
-        self.assertEqual(resolved.structuredContent["matches"][0]["id"], "cisco_aci")
-        self.assertFalse(ambiguous.isError)
-        self.assertEqual(ambiguous.structuredContent["status"], "ambiguous")
+        self.assertFalse(resolved.is_error)
+        self.assertEqual(resolved.structured_content["status"], "resolved")
+        self.assertEqual(resolved.structured_content["matches"][0]["id"], "cisco_aci")
+        self.assertFalse(ambiguous.is_error)
+        self.assertEqual(ambiguous.structured_content["status"], "ambiguous")
         self.assertEqual(
-            [item["id"] for item in ambiguous.structuredContent["matches"]],
+            [item["id"] for item in ambiguous.structured_content["matches"]],
             ["cisco_asa_ftd_syslog", "cisco_secure_firewall"],
         )
 
     async def test_discovery_paginates_and_rejects_file_traversal(self) -> None:
         async with self.session() as client:
             first = await client.call_tool("search_skills", {"limit": 1})
-            self.assertFalse(first.isError)
-            first_payload = first.structuredContent
+            self.assertFalse(first.is_error)
+            first_payload = first.structured_content
             self.assertGreater(first_payload["total"], 1)
             self.assertIsNotNone(first_payload["next_cursor"])
 
@@ -334,21 +333,21 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
                 },
             )
 
-        self.assertFalse(second.isError)
+        self.assertFalse(second.is_error)
         self.assertNotEqual(
             first_payload["skills"][0]["skill"],
-            second.structuredContent["skills"][0]["skill"],
+            second.structured_content["skills"][0]["skill"],
         )
-        self.assertFalse(listing.isError)
-        self.assertEqual(listing.structuredContent["files"][0]["path"], "SKILL.md")
-        self.assertFalse(bounded_read.isError)
+        self.assertFalse(listing.is_error)
+        self.assertEqual(listing.structured_content["files"][0]["path"], "SKILL.md")
+        self.assertFalse(bounded_read.is_error)
         self.assertLessEqual(
-            len(bounded_read.structuredContent["text"].encode("utf-8")),
+            len(bounded_read.structured_content["text"].encode("utf-8")),
             64,
         )
-        self.assertTrue(traversal.isError)
+        self.assertTrue(traversal.is_error)
         self.assertIn("path", traversal.content[0].text.lower())
-        self.assertTrue(script_read.isError)
+        self.assertTrue(script_read.is_error)
         self.assertIn("curated", script_read.content[0].text.lower())
 
     async def test_legacy_catalog_view_describes_canonical_only_traversal(self) -> None:
@@ -357,8 +356,8 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
         async with self.session() as client:
             result = await client.call_tool("list_skills", {})
 
-        self.assertFalse(result.isError)
-        payload = result.structuredContent
+        self.assertFalse(result.is_error)
+        payload = result.structured_content
         note = payload["compatibility_note"]
         self.assertEqual(payload["total"], canonical_count)
         self.assertEqual(
@@ -400,7 +399,7 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
     async def test_prompt_validation_is_sanitized_and_uses_invalid_params(self) -> None:
         sentinel = "protocol-test-secret-value-do-not-echo"
         async with self.session() as client:
-            with self.assertRaises(McpError) as raised:
+            with self.assertRaises(MCPError) as raised:
                 await client.get_prompt(
                     "plan_cisco_product_workflow",
                     {"product": "Cisco ACI", "phase": sentinel},
@@ -425,11 +424,11 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
                 f"skills://{sentinel}/not-a-resource",
                 "skills://definitely-not-a-skill/instructions",
             ):
-                with self.subTest(uri=uri), self.assertRaises(McpError) as raised:
+                with self.subTest(uri=uri), self.assertRaises(MCPError) as raised:
                     await client.read_resource(uri)  # type: ignore[arg-type]
 
                 error = raised.exception.error
-                self.assertEqual(error.code, -32002)
+                self.assertEqual(error.code, mcp_types.INVALID_PARAMS)
                 self.assertIn("Resource not found", error.message)
                 self.assertNotIn(sentinel, str(error.model_dump(mode="json")))
 
@@ -443,9 +442,9 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
                     "args": ["--help"],
                 },
             )
-            self.assertFalse(planned.isError)
-            self.assertFalse(planned.structuredContent["read_only"])
-            plan_hash = planned.structuredContent["plan_hash"]
+            self.assertFalse(planned.is_error)
+            self.assertFalse(planned.structured_content["read_only"])
+            plan_hash = planned.structured_content["plan_hash"]
 
             first = await client.call_tool(
                 "execute_skill_script",
@@ -456,9 +455,9 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
                 {"plan_hash": plan_hash, "confirm": True},
             )
 
-        self.assertTrue(first.isError)
+        self.assertTrue(first.is_error)
         self.assertIn("Subprocess execution is disabled", first.content[0].text)
-        self.assertTrue(second.isError)
+        self.assertTrue(second.is_error)
         self.assertIn("Subprocess execution is disabled", second.content[0].text)
 
     async def test_generic_execution_requires_its_explicit_gate(self) -> None:
@@ -473,10 +472,10 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
             )
             blocked = await client.call_tool(
                 "execute_skill_script",
-                {"plan_hash": planned.structuredContent["plan_hash"], "confirm": True},
+                {"plan_hash": planned.structured_content["plan_hash"], "confirm": True},
             )
 
-        self.assertTrue(blocked.isError)
+        self.assertTrue(blocked.is_error)
         self.assertIn(
             "Generic skill-script execution is disabled", blocked.content[0].text
         )
@@ -496,10 +495,10 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
             )
             blocked = await client.call_tool(
                 "execute_skill_script",
-                {"plan_hash": planned.structuredContent["plan_hash"], "confirm": True},
+                {"plan_hash": planned.structured_content["plan_hash"], "confirm": True},
             )
 
-        self.assertTrue(blocked.isError)
+        self.assertTrue(blocked.is_error)
         self.assertIn("Mutating execution is disabled", blocked.content[0].text)
 
     async def test_nonzero_execution_sets_is_error_and_plan_is_single_use(self) -> None:
@@ -516,7 +515,7 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
                     "args": ["--definitely-invalid"],
                 },
             )
-            plan_hash = planned.structuredContent["plan_hash"]
+            plan_hash = planned.structured_content["plan_hash"]
             failed = await client.call_tool(
                 "execute_skill_script",
                 {"plan_hash": plan_hash, "confirm": True},
@@ -526,10 +525,10 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
                 {"plan_hash": plan_hash, "confirm": True},
             )
 
-        self.assertTrue(failed.isError)
-        self.assertFalse(failed.structuredContent["ok"])
-        self.assertNotEqual(failed.structuredContent["returncode"], 0)
-        self.assertTrue(replay.isError)
+        self.assertTrue(failed.is_error)
+        self.assertFalse(failed.structured_content["ok"])
+        self.assertNotEqual(failed.structured_content["returncode"], 0)
+        self.assertTrue(replay.is_error)
         self.assertIn("Unknown plan_hash", replay.content[0].text)
 
 

--- a/tests/test_agent_mcp_protocol.py
+++ b/tests/test_agent_mcp_protocol.py
@@ -423,6 +423,7 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
             for uri in (
                 f"skills://{sentinel}/not-a-resource",
                 "skills://definitely-not-a-skill/instructions",
+                "skills://%2E%2E/instructions",
             ):
                 with self.subTest(uri=uri), self.assertRaises(MCPError) as raised:
                     await client.read_resource(uri)  # type: ignore[arg-type]
@@ -534,6 +535,37 @@ class AgentMCPProtocolTests(unittest.IsolatedAsyncioTestCase):
 
 @unittest.skipIf(ClientSession is None, "requires requirements-agent.txt")
 class AgentMCPRawStdioTests(unittest.TestCase):
+    def test_batch_required_protocol_version_is_not_negotiated(self) -> None:
+        initialize = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "protocol-test", "version": "1.0"},
+            },
+        }
+        env = os.environ.copy()
+        env["SPLUNK_CISCO_SKILLS_MCP_NO_VENV"] = "1"
+        process = subprocess.Popen(
+            [sys.executable, "-I", str(RUNNER)],
+            cwd=REPO_ROOT,
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        frame = json.dumps(initialize, separators=(",", ":")).encode() + b"\n"
+        stdout, stderr = process.communicate(input=frame, timeout=20)
+
+        self.assertEqual(process.returncode, 0, msg=stderr.decode(errors="replace"))
+        response = json.loads(stdout.splitlines()[0])
+        self.assertNotEqual(
+            response["result"]["protocolVersion"],
+            "2025-03-26",
+        )
+
     def test_raw_transport_bounds_and_sanitizes_invalid_frames(self) -> None:
         sentinel = b"raw-transport-secret-do-not-echo"
         frames = [


### PR DESCRIPTION
## Summary

- Migrate the repo-local skills MCP server and protocol tests from MCP SDK v1/FastMCP to MCP SDK v2/MCPServer.
- Preserve strict schemas, sanitized protocol errors, traversal defenses, and execution-gate responses under the v2 error model.
- Update Ruff to 0.16 and make the established Pyflakes/pycodestyle rule baseline explicit.

Supersedes the closed Dependabot updates #72 and #73.

## Validated

- `python -m pytest tests/test_agent_mcp_protocol.py -v` (15 passed, 21 subtests)
- `pre-commit run --all-files`
- `ruff check skills/ tests/ agent/ scripts/`
- `pip check` and `pip-audit` against both requirements files

The repository CI will also run the MCP protocol suite on Python 3.10 and 3.14.
