### PR TITLE
Isolate Galileo apply-all test from live endpoint

### DIFF
--- a/tests/test_galileo_platform_setup.py
+++ b/tests/test_galileo_platform_setup.py
@@ -1094,7 +1094,13 @@ def test_o11y_only_default_apply_dry_run_selects_cloud_sections(tmp_path: Path) 
         assert platform_section not in payload["selected_sections"]
 
 
-def test_o11y_only_apply_all_uses_cloud_sections_before_apply(tmp_path: Path) -> None:
+def test_o11y_only_apply_all_uses_cloud_sections_before_apply(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    healthcheck = tmp_path / "galileo-healthcheck"
+    healthcheck.write_text("ok\n", encoding="utf-8")
+    monkeypatch.setenv("GALILEO_HEALTH_URL", healthcheck.as_uri())
+
     result = run_cmd(
         "bash",
         str(SETUP),


### PR DESCRIPTION
## Summary
- replace the live Galileo readiness dependency in the apply-all regression with a local file fixture
- preserve production readiness behavior and the test coverage for O11y-only section expansion and missing-key validation

## Why
The live demo endpoint began serving a self-signed certificate, causing the otherwise unrelated full Python suite to fail before the test reached its intended assertion. This reproduces on unchanged main and was discovered while validating #75.

## Validation
- 97 Galileo platform tests passed
- all pre-commit hooks passed
- targeted formerly failing test passed